### PR TITLE
Add repo write permission

### DIFF
--- a/.github/workflows/tag-on-merge.yaml
+++ b/.github/workflows/tag-on-merge.yaml
@@ -10,6 +10,8 @@ jobs:
   create-tag:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
 ## Link to Issue or Slack thread
https://github.com/LabAutomationAndScreening/copier-base-template/actions/runs/12660125665/job/35280683937#step:3:19


 ## Why is this change necessary?
Permission error in action attempting to actually tag


 ## How does this change address the issue?
Adds write permission


 ## What side effects does this change have?
Hopefully it will work


 ## How is this change tested?
Isn't

