### PR TITLE
Add Contributing and Code of Conduct docs

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -8,3 +8,5 @@ git config --global --add safe.directory /workspaces/copier-base-template
 sh .devcontainer/on-create-command-boilerplate.sh
 
 sh .devcontainer/manual-setup-deps.sh
+
+pre-commit install --install-hooks

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## 📜 Our Pledge
+
+We, as members, contributors, and leaders of this project, pledge to make participation in our community a **harassment-free experience for everyone**, regardless of:
+
+- Age
+- Body size
+- Visible or invisible disability
+- Ethnicity
+- Gender identity and expression
+- Level of experience
+- Nationality
+- Personal appearance
+- Race
+- Religion
+- Sexual identity and orientation
+
+We are committed to fostering an environment where everyone feels **respected, safe, and welcome**.
+
+---
+
+## 🤝 Our Standards
+
+Examples of behavior that contribute to a positive environment include:
+
+- Using **welcoming and inclusive** language
+- Being **respectful** of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is **best for the community**
+- Showing **empathy** towards other community members
+
+Examples of unacceptable behavior include:
+
+- Using **sexualized language or imagery**, or making sexual advances
+- **Trolling**, insulting, or derogatory comments
+- Public or private **harassment**
+- Publishing private information, such as a physical or electronic address, without explicit permission
+- Conduct that is otherwise **inappropriate, threatening, or offensive**
+
+---
+
+## 🛠️ Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing this **Code of Conduct** and are expected to take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to **remove, edit, or reject comments, commits, code, issues, and other contributions** that are not aligned with this Code of Conduct.
+
+---
+
+## 🚨 Reporting Issues
+
+If you experience or witness unacceptable behavior, or have concerns about a possible violation of this Code of Conduct, please report it by:
+
+- **Contacting a maintainer directly**
+
+Reports will be handled with **confidentiality**. We are committed to addressing issues promptly and fairly.
+
+---
+
+## 📅 Enforcement Guidelines
+
+Project maintainers will follow these guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Warning:** A private, written warning with clarity on what behavior was inappropriate.
+2. **Temporary Ban:** A temporary suspension from interacting within the community.
+3. **Permanent Ban:** A permanent ban from the community or project spaces.
+
+---
+
+## 📜 Scope
+
+This Code of Conduct applies in all project spaces, including:
+
+- GitHub repository
+- Pull requests and issues
+- Project-related communication channels (e.g., chat, email)
+
+It also applies when an individual is officially representing the project in public spaces.
+
+---
+
+## 📝 Attribution
+
+This Code of Conduct is adapted from the **Contributor Covenant**, version 2.1, available at:
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+
+For answers to common questions about this code of conduct, see:
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)
+
+---
+
+Thank you for helping make this community a safe, welcoming, and productive space for everyone! 🚀

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing
+
+Thank you for considering contributing! Contributions, whether big or small, are always welcome. Below are guidelines to help you get started.
+
+---
+
+## 📚 Table of Contents
+
+1. [Code of Conduct](#code-of-conduct)
+2. [How to Contribute](#how-to-contribute)
+3. [Issues and Bug Reports](#issues-and-bug-reports)
+4. [Feature Requests](#feature-requests)
+5. [Development Guidelines](#development-guidelines)
+6. [Pull Requests](#pull-requests)
+7. [License](#license)
+
+---
+
+## 📜 Code of Conduct
+
+By participating in this project, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). Please ensure that you read and understand it.
+
+---
+
+## 🛠️ How to Contribute
+
+1. **Fork the repository** on GitHub.
+
+2. **Set up the Dev Container (Recommended Method)**
+   - Click on the "Open in Devcontainer" link in the Readme OR create a Github Codespcae
+
+3. **Make Your Changes**
+   - Create a branch for your feature or bug fix:
+     ```bash
+     git checkout -b feature/your-feature-name
+     ```
+   - Make your changes and test them within the dev container.
+
+4. **Commit Your Changes**
+   ```bash
+   git add .
+   git commit -m "Add your detailed commit message"
+   ```
+
+5. **Push Your Changes**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+6. **Open a Pull Request (PR)**
+   - Go to the original repository on GitHub.
+   - Click **"New Pull Request"**.
+   - Fill in the PR template and submit.
+
+---
+
+### 🐳 Why Use the Dev Container?
+
+- Pre-configured environment ensures consistency across development setups.
+- No need to manually install dependencies locally.
+- Simplifies debugging and testing workflows.
+
+If you encounter issues with the dev container, feel free to raise an **Issue**.
+
+---
+
+## 🐞 Issues and Bug Reports
+
+If you encounter a bug or issue:
+- Check if it’s already reported in the Issues section.
+- If not, open a **new issue** with:
+  - A clear and descriptive title.
+  - Steps to reproduce the issue.
+  - Expected and actual behavior.
+  - Any relevant logs, screenshots, or environment details.
+
+---
+
+## 💡 Feature Requests
+
+We love hearing new ideas! If you have an idea for a feature:
+- Search existing issues to ensure it hasn't been suggested already.
+- Open a new **Feature Request** issue and describe:
+   - What the feature does.
+   - Why it’s beneficial.
+   - How you envision it being implemented.
+
+---
+
+## 🧑‍💻 Development Guidelines
+
+- Follow the project's code style.
+- Write clear and descriptive commit messages.
+- Use Test Driven Development when adding new features or fixing bugs.
+- Keep changes focused; avoid mixing unrelated changes in one pull request.
+
+---
+
+## 🔄 Pull Requests
+
+- Ensure your pull request is focused on a single feature or bug fix.
+- Reference the issue your pull request addresses (if applicable).
+- Update documentation if your changes require it.
+- Be ready to address feedback or changes requested during code review.
+
+---
+
+## 📜 License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project: [LICENSE](./LICENSE).
+
+---
+
+Thank you for your contribution! 🚀
+
+If you have any questions, feel free to raise an **Issue**. 😊

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,12 @@ Thank you for considering contributing! Contributions, whether big or small, are
 ## 📚 Table of Contents
 
 1. [Code of Conduct](#-code-of-conduct)
-2. [How to Contribute](#how-to-contribute)
-3. [Issues and Bug Reports](#issues-and-bug-reports)
-4. [Feature Requests](#feature-requests)
-5. [Development Guidelines](#development-guidelines)
-6. [Pull Requests](#pull-requests)
-7. [License](#license)
+2. [How to Contribute](#-how-to-contribute)
+3. [Issues and Bug Reports](#-issues-and-bug-reports)
+4. [Feature Requests](#-feature-requests)
+5. [Development Guidelines](#-development-guidelines)
+6. [Pull Requests](#-pull-requests)
+7. [License](#-license)
 
 ---
 
@@ -27,7 +27,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](./
 1. **Fork the repository** on GitHub.
 
 2. **Set up the Dev Container (Recommended Method)**
-   - Click on the "Open in Devcontainer" link in the Readme OR create a Github Codespcae
+   - Create a Github Codespcae OR click on the "Open in Devcontainer" link in the [Readme](./README.md)
 
 3. **Make Your Changes**
    - Create a branch for your feature or bug fix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](./
 1. **Fork the repository** on GitHub.
 
 2. **Set up the Dev Container (Recommended Method)**
-   - Create a Github Codespcae OR click on the "Open in Devcontainer" link in the [Readme](./README.md)
+   - Create a Github Codespace (`Code`->`Codespaces` in the Github web console of your cloned repository) OR click on the "Open in Devcontainer" link in the [Readme](./README.md)
 
 3. **Make Your Changes**
    - Create a branch for your feature or bug fix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for considering contributing! Contributions, whether big or small, are
 
 ## 📚 Table of Contents
 
-1. [Code of Conduct](#code-of-conduct)
+1. [Code of Conduct](#-code-of-conduct)
 2. [How to Contribute](#how-to-contribute)
 3. [Issues and Bug Reports](#issues-and-bug-reports)
 4. [Feature Requests](#feature-requests)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # Instantiating a new repository using this template
 1. Use the file `.devcontainer/devcontainer-to-instantiate-template.json` to create a devcontainer
 2. Inside that devcontainer, run the `.devcontainer/install-ci-tooling.sh` script
-3. Run copier to instantiate the template: `copier copy --vcs-ref main --trust gh:LabAutomationAndScreening/copier-base-template.git .`
+3. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-base-template.git .`
 4. Run `uv lock` to generate the lock file
 5. Commit the changes
 6. Rebuild your new devcontainer

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -5,4 +5,8 @@ set -ex
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
 git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% raw %}
 
-sh .devcontainer/on-create-command-boilerplate.sh{% endraw %}
+sh .devcontainer/on-create-command-boilerplate.sh
+
+sh .devcontainer/manual-setup-deps.sh
+
+pre-commit install --install-hooks{% endraw %}

--- a/template/CODE_OF_CONDUCT.md
+++ b/template/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../CODE_OF_CONDUCT.md

--- a/template/CONTRIBUTING.md
+++ b/template/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/template/README.md.jinja-base
+++ b/template/README.md.jinja-base
@@ -8,6 +8,6 @@
 
 
 
-# Updating from the template
+## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:
 `copier update --trust --defaults --conflict rej`{% endraw %}

--- a/template/README.md.jinja-base
+++ b/template/README.md.jinja-base
@@ -10,4 +10,4 @@
 
 # Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:
-`copier update --trust --defaults --conflict rej --vcs-ref main`{% endraw %}
+`copier update --trust --defaults --conflict rej`{% endraw %}

--- a/template/template/CODE_OF_CONDUCT.md
+++ b/template/template/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../../CODE_OF_CONDUCT.md

--- a/template/template/CONTRIBUTING.md
+++ b/template/template/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../CONTRIBUTING.md


### PR DESCRIPTION
 ## Why is this change necessary?
Need more generic repo standard files


 ## How does this change address the issue?
Adds contributing and Code of Conduct docs


 ## What side effects does this change have?
None


 ## How is this change tested?
pyalab repo


 ## Other
Also installing pre-commit hooks in the devcontainer bulid