### PR TITLE
Mount venv as volume

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,5 +7,12 @@ RUN apt-get update -y && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Create the venv folder and set permissions for anyone to modify---this is necessary to be able to break out the venv folder as a separate docker volume for better performance on Windows hosts
+ARG VENV_PATH=/workspaces/copier-base-template/.venv
+RUN mkdir -p /workspace && \
+    mkdir -p ${VENV_PATH} && \
+    chmod -R 777 /workspaces ${VENV_PATH} && \
+    chgrp -R 0 /workspaces ${VENV_PATH}
+
 # SSH
 EXPOSE 2222

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,12 +2,16 @@ version: '3.8'
 services:
   devcontainer:
     build: .
-    # can run `devcontainer-info content-url` in codespaces to see what image base is
+    # You can run `devcontainer-info content-url` in codespaces to see what image base is
     volumes:
       - ..:/workspaces/copier-base-template:cached
+      # Break out the venv folder as a separate docker volume for better performance on Windows hosts
       - python_venv:/workspaces/copier-base-template/.venv
     command: sleep infinity
     ports:
       - "14343:2222"
     environment:
       - AWS_PROFILE=localstack
+
+volumes:
+  python_venv: {}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     # can run `devcontainer-info content-url` in codespaces to see what image base is
     volumes:
       - ..:/workspaces/copier-base-template:cached
+      - python_venv:/workspaces/copier-base-template/.venv
     command: sleep infinity
     ports:
       - "14343:2222"

--- a/.devcontainer/install-ci-tooling.sh
+++ b/.devcontainer/install-ci-tooling.sh
@@ -2,7 +2,7 @@
 # can pass in the full major.minor.patch version of python as an optional argument
 set -ex
 
-curl -LsSf https://astral.sh/uv/0.5.10/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.5.16/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -11,7 +11,7 @@ class ContextUpdater(ContextHook):
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
         # These are duplicated in the install-ci-tooling.sh script in this repository
-        context["uv_version"] = "0.5.10"
+        context["uv_version"] = "0.5.16"
         context["pre_commit_version"] = "4.0.1"
         # These also in pyproject.toml
         context["copier_version"] = "9.4.1"

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -2,12 +2,17 @@
 services:
   devcontainer:
     build: .
-    # can run `devcontainer-info content-url` in codespaces to see what image base is
+    # You can run `devcontainer-info content-url` in codespaces to see what image base is
     volumes:
       - ..:/workspaces/{% endraw %}{{ repo_name }}{% raw %}:cached
+      # Break out the venv folder as a separate docker volume for better performance on Windows hosts
       - python_venv:/workspaces/{% endraw %}{{ repo_name }}{% raw %}/.venv
     command: sleep infinity
     ports:
       - "{% endraw %}{{ ssh_port_number }}{% raw %}:2222"
     environment:
       - AWS_PROFILE=localstack{% endraw %}
+
+
+volumes:
+  python_venv: {}

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -5,6 +5,7 @@ services:
     # can run `devcontainer-info content-url` in codespaces to see what image base is
     volumes:
       - ..:/workspaces/{% endraw %}{{ repo_name }}{% raw %}:cached
+      - python_venv:/workspaces/{% endraw %}{{ repo_name }}{% raw %}/.venv
     command: sleep infinity
     ports:
       - "{% endraw %}{{ ssh_port_number }}{% raw %}:2222"

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -1,7 +1,10 @@
 {% raw %}version: '3.8'
 services:
   devcontainer:
-    build: .
+    build:
+      context: .
+      args:
+        VENV_PATH: /workspaces/{% endraw %}{{ repo_name }}{% raw %}/.venv
     # You can run `devcontainer-info content-url` in codespaces to see what image base is
     volumes:
       - ..:/workspaces/{% endraw %}{{ repo_name }}{% raw %}:cached


### PR DESCRIPTION
 ## Why is this change necessary?
Improve performance on Windows hosts


 ## How does this change address the issue?
Moves the python venv folder into a dedicated separate docker volume


 ## What side effects does this change have?
venv folder won't show up on local hard drive


 ## How is this change tested?
In this repo, and pyalab repo and in pyalab codespace.  pyalab Pytest execution time was previous 2 second in Codespaces and 16 seconds on Windows host---this dropped it to 4 seconds on Windows host.


 ## Other
Bumped uv version
