### PR TITLE
Install from CodeArtifact

### DIFF
--- a/.devcontainer/create-aws-profile.sh
+++ b/.devcontainer/create-aws-profile.sh
@@ -9,14 +9,15 @@ else
   LOCALSTACK_ENDPOINT_URL="http://localstack:4566"
 fi
 
+cat >> ~/.aws/credentials <<EOF
+[localstack]
+aws_access_key_id=test
+aws_secret_access_key=test
+EOF
+
 cat >> ~/.aws/config <<EOF
 [profile localstack]
 region=us-east-1
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
-EOF
-cat >> ~/.aws/credentials <<EOF
-[localstack]
-aws_access_key_id=test
-aws_secret_access_key=test
 EOF

--- a/template/.devcontainer/create-aws-profile.sh
+++ b/template/.devcontainer/create-aws-profile.sh
@@ -1,1 +1,0 @@
-../../.devcontainer/create-aws-profile.sh

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -10,11 +10,11 @@ else
 fi
 
 cat >> ~/.aws/config <<EOF
-[profile development]
+{% endraw %}{% if aws_production_account_id is defined %}{% raw %}[profile development]
 sso_session = org
 sso_account_id = {% endraw %}{{ aws_development_account_id if use_staging_environment else aws_production_account_id }}{% raw %}
 sso_role_name = LowRiskAccountAdminAccess
-region = {% endraw %}{{ aws_org_home_region }}{% raw %}
+region = {% endraw %}{{ aws_org_home_region }}{% raw %}{% endraw %}{% endif %}{% raw %}
 
 [sso-session org]
 sso_start_url = https://{% endraw %}{{ aws_identity_center_id }}{% raw %}.awsapps.com/start
@@ -22,7 +22,7 @@ sso_region = {% endraw %}{{ aws_org_home_region }}{% raw %}
 sso_registration_scopes = sso:account:access
 
 [profile localstack]
-region={% endraw %}{{ aws_org_home_region }}{% raw %}
+region={% endraw %}{{ aws_org_home_region if aws_org_home_region is defined else "us-east-1" }}{% raw %}
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
 

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -19,7 +19,7 @@ region = {% endraw %}{{ aws_org_home_region }}{% raw %}{% endraw %}{% endif %}{%
 {% endraw %}{% if aws_identity_center_id is defined and aws_identity_center_id != "" %}{% raw %}[sso-session org]
 sso_start_url = https://{% endraw %}{{ aws_identity_center_id }}{% raw %}.awsapps.com/start
 sso_region = {% endraw %}{{ aws_org_home_region }}{% raw %}
-sso_registration_scopes = sso:account:access{% raw %}{% endraw %}{% endif %}{% raw %}
+sso_registration_scopes = sso:account:access{% endraw %}{% endif %}{% raw %}
 
 [profile localstack]
 region={% endraw %}{{ aws_org_home_region if (aws_org_home_region is defined and aws_org_home_region != "") else "us-east-1" }}{% raw %}

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -2,6 +2,13 @@
 set -ex
 
 mkdir -p ~/.aws
+
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+  LOCALSTACK_ENDPOINT_URL="http://localhost:4566"
+else
+  LOCALSTACK_ENDPOINT_URL="http://localstack:4566"
+fi
+
 cat >> ~/.aws/config <<EOF
 [profile development]
 sso_session = org
@@ -17,7 +24,16 @@ sso_registration_scopes = sso:account:access
 [profile localstack]
 region={% endraw %}{{ aws_org_home_region }}{% raw %}
 output=json
-endpoint_url = http://localstack:4566
+endpoint_url = $LOCALSTACK_ENDPOINT_URL
+
+{% endraw %}{% if aws_central_infrastructure_account_id != "" }{% raw %}
+[profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}]
+sso_session = org
+sso_role_name = {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}
+sso_account_id = {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}
+region = {% endraw %}{{ aws_org_home_region }}{% raw %}
+
+{% endraw %}{% endif %}{% raw %}
 EOF
 cat >> ~/.aws/credentials <<EOF
 [localstack]

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -26,7 +26,7 @@ region={% endraw %}{{ aws_org_home_region if aws_org_home_region is defined else
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
 
-{% endraw %}{% if aws_central_infrastructure_account_id is defined %}{% raw %}
+{% endraw %}{% if aws_central_infrastructure_account_id is defined and aws_central_infrastructure_account_id != "" %}{% raw %}
 [profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}]
 sso_session = org
 sso_role_name = {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -16,10 +16,10 @@ sso_account_id = {% endraw %}{{ aws_development_account_id if use_staging_enviro
 sso_role_name = LowRiskAccountAdminAccess
 region = {% endraw %}{{ aws_org_home_region }}{% raw %}{% endraw %}{% endif %}{% raw %}
 
-[sso-session org]
+{% endraw %}{% if aws_identity_center_id is defined and aws_identity_center_id != "" %}{% raw %}[sso-session org]
 sso_start_url = https://{% endraw %}{{ aws_identity_center_id }}{% raw %}.awsapps.com/start
 sso_region = {% endraw %}{{ aws_org_home_region }}{% raw %}
-sso_registration_scopes = sso:account:access
+sso_registration_scopes = sso:account:access{% raw %}{% endraw %}{% endif %}{% raw %}
 
 [profile localstack]
 region={% endraw %}{{ aws_org_home_region if (aws_org_home_region is defined and aws_org_home_region != "") else "us-east-1" }}{% raw %}

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -26,7 +26,7 @@ region={% endraw %}{{ aws_org_home_region }}{% raw %}
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
 
-{% endraw %}{% if aws_central_infrastructure_account_id != "" %}{% raw %}
+{% endraw %}{% if aws_central_infrastructure_account_id is defined %}{% raw %}
 [profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}]
 sso_session = org
 sso_role_name = {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -26,7 +26,7 @@ region={% endraw %}{{ aws_org_home_region }}{% raw %}
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
 
-{% endraw %}{% if aws_central_infrastructure_account_id != "" }{% raw %}
+{% endraw %}{% if aws_central_infrastructure_account_id != "" %}{% raw %}
 [profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}]
 sso_session = org
 sso_role_name = {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -10,7 +10,7 @@ else
 fi
 
 cat >> ~/.aws/config <<EOF
-{% endraw %}{% if aws_production_account_id is defined %}{% raw %}[profile development]
+{% endraw %}{% if aws_production_account_id is defined and aws_production_account_id != "" %}{% raw %}[profile development]
 sso_session = org
 sso_account_id = {% endraw %}{{ aws_development_account_id if use_staging_environment else aws_production_account_id }}{% raw %}
 sso_role_name = LowRiskAccountAdminAccess
@@ -22,7 +22,7 @@ sso_region = {% endraw %}{{ aws_org_home_region }}{% raw %}
 sso_registration_scopes = sso:account:access
 
 [profile localstack]
-region={% endraw %}{{ aws_org_home_region if aws_org_home_region is defined else "us-east-1" }}{% raw %}
+region={% endraw %}{{ aws_org_home_region if (aws_org_home_region is defined and aws_org_home_region != "") else "us-east-1" }}{% raw %}
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
 

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -15,7 +15,7 @@ services:
       - "{% endraw %}{{ ssh_port_number }}{% raw %}:2222"
     environment:
       - AWS_PROFILE=localstack
-      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if (aws_org_home_region is defined and aws_org_home_region != "") else "us-east-1" }}{% raw %}
+      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if (aws_region_for_stack is defined and aws_region_for_stack != "") else "us-east-1" }}{% raw %}
 
 
 volumes:

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -15,7 +15,7 @@ services:
       - "{% endraw %}{{ ssh_port_number }}{% raw %}:2222"
     environment:
       - AWS_PROFILE=localstack
-      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if aws_region_for_stack is defined else "us-east-1" }}{% raw %}
+      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if (aws_org_home_region is defined and aws_org_home_region != "") else "us-east-1" }}{% raw %}
 
 
 volumes:

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -15,7 +15,7 @@ services:
       - "{% endraw %}{{ ssh_port_number }}{% raw %}:2222"
     environment:
       - AWS_PROFILE=localstack
-      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if aws_region_for_stack else "us-east-1" }}{% raw %}
+      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if aws_region_for_stack is defined else "us-east-1" }}{% raw %}
 
 
 volumes:

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -15,7 +15,7 @@ services:
       - "{% endraw %}{{ ssh_port_number }}{% raw %}:2222"
     environment:
       - AWS_PROFILE=localstack
-      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack }}{% raw %}
+      - AWS_DEFAULT_REGION={% endraw %}{{ aws_region_for_stack if aws_region_for_stack else "us-east-1" }}{% raw %}
 
 
 volumes:

--- a/template/.devcontainer/manual-setup-deps.sh.jinja-base
+++ b/template/.devcontainer/manual-setup-deps.sh.jinja-base
@@ -42,7 +42,6 @@ if [ "$optionally_lock" = "true" ]; then
 fi
 
 {% endraw %}{% if python_package_registry is defined and python_package_registry == "AWS CodeArtifact" %}{% raw %}
-aws sso login --profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}
 . "$SCRIPT_DIR/code-artifact-auth.sh"{% endraw %}{% endif %}{% raw %}
 
 # Ensure that the lock file is in a good state

--- a/template/.devcontainer/manual-setup-deps.sh.jinja-base
+++ b/template/.devcontainer/manual-setup-deps.sh.jinja-base
@@ -1,6 +1,8 @@
 {% raw %}#!/usr/bin/env sh
 # can pass in the full major.minor.patch version of python as an optional argument
 # can set `--skip-lock` as optional argument to just install dependencies without verifying lock file
+# can set `--optionally-lock` to check for a uv.lock file in the project directory and only respect the lock if it already exists (useful for initially instantiating the repository) (mutually exclusive with --skip-lock)
+
 set -ex
 
 # Ensure that uv won't use the default system Python
@@ -8,19 +10,40 @@ python_version="{% endraw %}{{ python_version }}{% raw %}"
 
 # Parse arguments
 skip_lock=false
+optionally_lock=false
 while [ "$#" -gt 0 ]; do
     case $1 in
         --skip-lock) skip_lock=true ;;
+        --optionally-lock) optionally_lock=true ;;
         *) python_version="${1:-$python_version}" ;; # Take the first non-flag argument as the input
     esac
     shift
 done
+
+# Ensure that --skip-lock and --optionally-lock are mutually exclusive
+if [ "$skip_lock" = "true" ] && [ "$optionally_lock" = "true" ]; then
+    echo "Error: --skip-lock and --optionally-lock cannot be used together." >&2
+    exit 1
+fi
 
 export UV_PYTHON="$python_version"
 export UV_PYTHON_PREFERENCE=only-system
 
 SCRIPT_DIR="$(dirname "$0")"
 PROJECT_ROOT_DIR="$(realpath "$SCRIPT_DIR/..")"
+
+# If optionally_lock is set, decide whether to skip locking based on the presence of uv.lock
+if [ "$optionally_lock" = "true" ]; then
+    if [ ! -f "$PROJECT_ROOT_DIR/uv.lock" ]; then
+        skip_lock=true
+    else
+        skip_lock=false
+    fi
+fi
+
+{% endraw %}{% if python_package_registry is defined and python_package_registry == "AWS CodeArtifact" %}{% raw %}
+aws sso login --profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}
+. "$SCRIPT_DIR/code-artifact-auth.sh"{% endraw %}{% endif %}{% raw %}
 
 # Ensure that the lock file is in a good state
 if [ "$skip_lock" = "false" ]; then

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -7,8 +7,6 @@ git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}
 
 sh .devcontainer/on-create-command-boilerplate.sh
 
-pre-commit install --install-hooks
+pre-commit install --install-hooks{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}
 
-{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}{% raw %}
-
-{% endraw %}
+{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -7,6 +7,6 @@ git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}
 
 sh .devcontainer/on-create-command-boilerplate.sh
 
-sh .devcontainer/manual-setup-deps.sh
+{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPi" %}{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}{% raw %}
 
 pre-commit install --install-hooks{% endraw %}

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -9,4 +9,4 @@ sh .devcontainer/on-create-command-boilerplate.sh
 
 pre-commit install --install-hooks{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}
 
-{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}
+{% raw %}sh .devcontainer/manual-setup-deps.sh --optionally-lock{% endraw %}{% endif %}

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -7,6 +7,8 @@ git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}
 
 sh .devcontainer/on-create-command-boilerplate.sh
 
+pre-commit install --install-hooks
+
 {% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}{% raw %}
 
-pre-commit install --install-hooks{% endraw %}
+{% endraw %}

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -7,6 +7,6 @@ git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}
 
 sh .devcontainer/on-create-command-boilerplate.sh
 
-{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPi" %}{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}{% raw %}
+{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}{% raw %}sh .devcontainer/manual-setup-deps.sh{% endraw %}{% endif %}{% raw %}
 
 pre-commit install --install-hooks{% endraw %}

--- a/template/.devcontainer/post-start-command.sh.jinja-base
+++ b/template/.devcontainer/post-start-command.sh.jinja-base
@@ -3,5 +3,5 @@ set -ex
 
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
-git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% if python_package_registry is defined and python_package_registry == "PyPI" %}{% raw %}
+git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% if python_package_registry is defined and python_package_registry =! "PyPI" %}{% raw %}
 echo "!!! In order to install dependencies, you must authenticate into the private registry, so run this script to complete the process: sh .devcontainer/manual-setup-deps.sh"{% endraw %}{% endif %}

--- a/template/.devcontainer/post-start-command.sh.jinja-base
+++ b/template/.devcontainer/post-start-command.sh.jinja-base
@@ -3,5 +3,5 @@ set -ex
 
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
-git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% if python_package_registry is defined and python_package_registry =! "PyPI" %}{% raw %}
+git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% if python_package_registry is defined and python_package_registry != "PyPI" %}{% raw %}
 echo "!!! In order to install dependencies, you must authenticate into the private registry, so run this script to complete the process: sh .devcontainer/manual-setup-deps.sh"{% endraw %}{% endif %}

--- a/template/.devcontainer/post-start-command.sh.jinja-base
+++ b/template/.devcontainer/post-start-command.sh.jinja-base
@@ -3,4 +3,5 @@ set -ex
 
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
-git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}
+git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% if python_package_registry is defined and python_package_registry == "PyPI" %}{% raw %}
+echo "!!! In order to install dependencies, you must authenticate into the private registry, so run this script to complete the process: sh .devcontainer/manual-setup-deps.sh"{% endraw %}{% endif %}

--- a/template/.devcontainer/post-start-command.sh.jinja-base
+++ b/template/.devcontainer/post-start-command.sh.jinja-base
@@ -4,4 +4,4 @@ set -ex
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
 git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% if python_package_registry is defined and python_package_registry != "PyPI" %}{% raw %}
-echo "!!! In order to install dependencies, you must authenticate into the private registry, so run this script to complete the process: sh .devcontainer/manual-setup-deps.sh"{% endraw %}{% endif %}
+echo "!!! In order to install dependencies, you must authenticate into the private registry, so run this script to complete the process: source .devcontainer/manual-setup-deps.sh"{% endraw %}{% endif %}

--- a/template/.github/actions/install_deps_uv/action.yml.jinja-base
+++ b/template/.github/actions/install_deps_uv/action.yml.jinja-base
@@ -55,7 +55,7 @@ runs:
       shell: pwsh
 
     - name: OIDC Auth for CodeArtifact
-      if: ${{ inputs.code-artifact-auth-role-name != "no-code-artifact" }}
+      if: ${{ inputs.code-artifact-auth-role-name != 'no-code-artifact' }}
       uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
       with:
         role-to-assume: arn:aws:iam::${{ inputs.code-artifact-auth-role-account-id }}:role/${{ inputs.code-artifact-auth-role-name }}

--- a/template/.github/actions/install_deps_uv/action.yml.jinja-base
+++ b/template/.github/actions/install_deps_uv/action.yml.jinja-base
@@ -14,6 +14,19 @@ inputs:
     description: What's the relative path to the project?
     required: false
     default: ./
+  code-artifact-auth-role-name:
+    type: string
+    description: What's the role name to use for CodeArtifact authentication?
+    required: false
+    default: no-code-artifact
+  code-artifact-auth-role-account-id:
+    type: string
+    description: What's the AWS Account ID that the role is in?
+    required: false
+  code-artifact-auth-region:
+    type: string
+    description: What region should the role use?
+    required: false
 
 
 runs:
@@ -41,11 +54,21 @@ runs:
       run: .github/actions/install_deps_uv/install-ci-tooling.ps1 ${{ env.PYTHON_VERSION }}
       shell: pwsh
 
+    - name: OIDC Auth for CodeArtifact
+      if: ${{ inputs.code-artifact-auth-role-name != "no-code-artifact" }}
+      uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
+      with:
+        role-to-assume: arn:aws:iam::${{ inputs.code-artifact-auth-role-account-id }}:role/${{ inputs.code-artifact-auth-role-name }}
+        aws-region: ${{ inputs.code-artifact-auth-region }}
+
     - name: Install Dependencies (Linux)
       if: ${{ inputs.uv-sync && runner.os == 'Linux' }}
       run: |
         sh .devcontainer/manual-setup-deps.sh ${{ env.PYTHON_VERSION }}
       shell: bash
+
+
+
 
     - name: Install Dependencies (Windows)
       if: ${{ inputs.uv-sync && runner.os == 'Windows' }}

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -107,6 +107,8 @@ jobs:
         env:
           CODEARTIFACT_AUTH_TOKEN: 'faketoken'
         run: |
+          # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
+          find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{/^default = true$/d}' {} +
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them
           git add .

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -110,7 +110,6 @@ jobs:
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
           find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{s/^\(default = true\)$/\1\nname = "pypi"\nurl = "https:\/\/pypi.org\/simple\/"\n[[tool.uv.index]]/}' {} +
-          ls uv.* -a
           cat pyproject.toml
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -104,6 +104,8 @@ jobs:
 
 
       - name: install new dependencies
+        env:
+          CODEARTIFACT_AUTH_TOKEN=faketoken
         run: |
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -109,6 +109,7 @@ jobs:
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
           find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{s/^\(default = true\)$/\1\nname = "pypi"\nurl = "https:\/\/pypi.org\/simple\/"\n[[tool.uv.index]]/}' {} +
+          ls uv.* -a
           cat pyproject.toml
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -109,6 +109,7 @@ jobs:
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
           find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{/^default = true$/d}' {} +
+          cat pyproject.toml
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them
           git add .

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -57,7 +57,6 @@ jobs:
   lint-matrix:
     needs: [ pre-commit ]
     strategy:
-      fail-fast: false
       matrix:
         os:
           - "{% endraw %}{{ gha_linux_runner }}{% raw %}"
@@ -74,6 +73,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+
+      - name: Move python script that replaces private package registry information to temp folder so it doesn't get deleted
+        run |
+          mv .github/workflows/replace_private_package_registries.py $RUNNER_TEMP
 
       - name: Install python tooling
         uses: ./.github/actions/install_deps_uv
@@ -110,8 +113,7 @@ jobs:
           UV_NO_CACHE: 'true'
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
-          python .github/workflows/replace_private_package_registries.py
-          cat pyproject.toml
+          python $RUNNER_TEMP/replace_private_package_registries.py
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them
           git add .

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -106,6 +106,7 @@ jobs:
       - name: install new dependencies
         env:
           CODEARTIFACT_AUTH_TOKEN: 'faketoken'
+          UV_NO_CACHE: 'true'
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
           find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{s/^\(default = true\)$/\1\nname = "pypi"\nurl = "https:\/\/pypi.org\/simple\/"\n[[tool.uv.index]]/}' {} +

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
 
       - name: Move python script that replaces private package registry information to temp folder so it doesn't get deleted
-        run |
+        run: |
           mv .github/workflows/replace_private_package_registries.py $RUNNER_TEMP
 
       - name: Install python tooling

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -57,6 +57,7 @@ jobs:
   lint-matrix:
     needs: [ pre-commit ]
     strategy:
+      fail-fast: false
       matrix:
         os:
           - "{% endraw %}{{ gha_linux_runner }}{% raw %}"

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -108,7 +108,7 @@ jobs:
           CODEARTIFACT_AUTH_TOKEN: 'faketoken'
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
-          find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{/^default = true$/d}' {} +
+          find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{s/^\(default = true\)$/\1\nname = "pypi"\nurl = "https:\/\/pypi.org\/simple\/"\n[[tool.uv.index]]/}' {} +
           cat pyproject.toml
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -110,7 +110,7 @@ jobs:
           UV_NO_CACHE: 'true'
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
-          find . -maxdepth 3 -type f -name "pyproject.toml" -exec sed -i '/^\[\[tool\.uv\.index\]\]/, /^\[\[/{s/^\(default = true\)$/\1\nname = "pypi"\nurl = "https:\/\/pypi.org\/simple\/"\n[[tool.uv.index]]/}' {} +
+          python .github/workflows/replace_private_package_registries.py
           cat pyproject.toml
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -105,7 +105,7 @@ jobs:
 
       - name: install new dependencies
         env:
-          CODEARTIFACT_AUTH_TOKEN=faketoken
+          CODEARTIFACT_AUTH_TOKEN: 'faketoken'
         run: |
           sh .devcontainer/manual-setup-deps.sh ${{ matrix.python-version }} --skip-lock
           # Add everything to git so that pre-commit recognizes the files and runs on them

--- a/template/.github/workflows/replace_private_package_registries.py
+++ b/template/.github/workflows/replace_private_package_registries.py
@@ -1,0 +1,57 @@
+"""Update any project files that point to a private package registry to use public ones.
+
+Since the CI pipelines for testing these copier templates don't have access to private registries, we can't test installing from them as part of CI.
+
+Seems minimal risk, since the only problem we'd be missing is if the pyproject.toml (or similar config files) had syntax errors that would have been
+caught by pre-commit.
+"""
+
+import re
+from pathlib import Path
+
+
+def process_file(file_path: Path):
+    # Read the entire file content
+    content = file_path.read_text()
+
+    # Regex to match a block starting with [[tool.uv.index]]
+    # until the next block header (a line starting with [[) or the end of the file.
+    pattern = re.compile(r"(\[\[tool\.uv\.index\]\].*?)(?=\n\[\[|$)", re.DOTALL)
+
+    # Find all uv.index blocks.
+    blocks = pattern.findall(content)
+
+    # Check if any block contains "default = true"
+    if not any("default = true" in block for block in blocks):
+        print(f"No changes in: {file_path}")
+        return
+
+    # If at least one block contains "default = true", remove all uv.index blocks.
+    new_content = pattern.sub("", content)
+
+    # Ensure file ends with a newline before appending the new block.
+    if not new_content.endswith("\n"):
+        new_content += "\n"
+
+    # Append the new block.
+    new_block = '[[tool.uv.index]]\nname = "pypi"\nurl = "https://pypi.org/simple/"\n'
+    new_content += new_block
+
+    # Write the updated content back to the file.
+    _ = file_path.write_text(new_content)
+    print(f"Updated file: {file_path}")
+
+
+def main():
+    base_dir = Path(".")
+    # Use rglob to find all pyproject.toml files recursively.
+    for file_path in base_dir.rglob("pyproject.toml"):
+        # Check if the file is at most two levels deep.
+        # The relative path's parts count should be <= 3 (e.g. "pyproject.toml" is 1 part,
+        # "subdir/pyproject.toml" is 2 parts, and "subdir/subsubdir/pyproject.toml" is 3 parts).
+        if len(file_path.relative_to(base_dir).parts) <= 3:
+            process_file(file_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -46,13 +46,13 @@ python_ci_versions:
 aws_identity_center_id:
     type: str
     help: What's the ID of your Organization's AWS Identity center, e.g. d-9145c20053?
-    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}}}"
+    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}{% raw %}}}"
 
 aws_org_home_region:
     type: str
     help: What is the home region of the AWS Organization (where all of the central infrastructure is deployed)?
     default: us-east-1
-    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}}}"
+    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}{% raw %}}}"
 
 aws_central_infrastructure_account_id:
     type: str

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -42,7 +42,7 @@ python_ci_versions:
       - "{{ py312_version }}"
       - "{{ py313_version }}"{% endif %}{% raw %}
 
-{% endraw %}{% if template_uses_pulumi or (template_uses_python and python_package_registry == "AWS CodeArtifact") %}{% raw %}
+{% endraw %}{% if template_uses_python %}{% raw %}
 aws_identity_center_id:
     type: str
     help: What's the ID of your Organization's AWS Identity center, e.g. d-9145c20053?
@@ -51,12 +51,11 @@ aws_org_home_region:
     type: str
     help: What is the home region of the AWS Organization (where all of the central infrastructure is deployed)?
     default: us-east-1
-{% endraw %}{% endif %}{% raw %}
 
-{% endraw %}{% if template_uses_python and python_package_registry == "AWS CodeArtifact" %}{% raw %}
 aws_central_infrastructure_account_id:
     type: str
     help: What's the ID of your Organization's AWS Account containing Central Infrastructure (e.g. CodeArtifact)?
+    when: "{{ python_package_registry == 'AWS CodeArtifact' }}"
 
 {% endraw %}{% endif %}{% raw %}
 

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -26,6 +26,14 @@ python_version:
     help: What version of Python is used for development?
     default: "{{ python_version }}"
 
+python_package_registry:
+    type: str
+    help: What registry should Python Packgaes be installed from?
+    choices:
+        - PyPI
+        - AWS CodeArtifact
+    default: PyPI
+
 python_ci_versions:
     type: str
     help: What versions should Python run CI on the instantiated template?

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -59,6 +59,12 @@ aws_central_infrastructure_account_id:
     help: What's the ID of your Organization's AWS Account containing Central Infrastructure (e.g. CodeArtifact)?
     when: "{{ python_package_registry == 'AWS CodeArtifact' }}"
 
+core_infra_base_access_profile_name:
+    type: str
+    help: What's the AWS Identity Center Profile name for base access to the Central Infrastructure account (i.e. to read from CodeArtifact)?
+    when: "{{ python_package_registry == 'AWS CodeArtifact' }}"
+    default: CoreInfraBaseAccess
+
 {% endraw %}{% endif %}{% raw %}
 
 {% endraw %}{% if template_uses_pulumi %}{% raw %}

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -42,7 +42,7 @@ python_ci_versions:
       - "{{ py312_version }}"
       - "{{ py313_version }}"{% endif %}{% raw %}
 
-{% endraw %}{% if template_uses_pulumi %}{% raw %}
+{% endraw %}{% if template_uses_pulumi or (template_uses_python and python_package_registry == "AWS CodeArtifact") %}{% raw %}
 aws_identity_center_id:
     type: str
     help: What's the ID of your Organization's AWS Identity center, e.g. d-9145c20053?
@@ -51,7 +51,16 @@ aws_org_home_region:
     type: str
     help: What is the home region of the AWS Organization (where all of the central infrastructure is deployed)?
     default: us-east-1
+{% endraw %}{% endif %}{% raw %}
 
+{% endraw %}{% if template_uses_python and python_package_registry == "AWS CodeArtifact" %}{% raw %}
+aws_central_infrastructure_account_id:
+    type: str
+    help: What's the ID of your Organization's AWS Account containing Central Infrastructure (e.g. CodeArtifact)?
+
+{% endraw %}{% endif %}{% raw %}
+
+{% endraw %}{% if template_uses_pulumi %}{% raw %}
 aws_production_account_id:
     type: str
     help: What's the AWS Account ID for the Production environment?

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -46,11 +46,13 @@ python_ci_versions:
 aws_identity_center_id:
     type: str
     help: What's the ID of your Organization's AWS Identity center, e.g. d-9145c20053?
+    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}}}"
 
 aws_org_home_region:
     type: str
     help: What is the home region of the AWS Organization (where all of the central infrastructure is deployed)?
     default: us-east-1
+    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}}}"
 
 aws_central_infrastructure_account_id:
     type: str

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -38,8 +38,10 @@ else
     fi
 
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_USERNAME=aws
+    echo "::add-mask::$UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD" # ensure this doesn't show up in the CI logs
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     export UV_INDEX_CODE_ARTIFACT_STAGING_USERNAME=aws
+    echo "::add-mask::$UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD" # ensure this doesn't show up in the CI logs
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -9,9 +9,32 @@ else
     # Only regenerate the token if it doesn't exist or wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
     if [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
         echo "Fetching CodeArtifact token"
-        # TODO: only re-login if the sso credentials have expired
-        aws sso login --profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}
-        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain {% endraw %}{{ repo_org_name }}{% raw %} --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} --region {% endraw %}{{ aws_org_home_region }}{% raw %} --query authorizationToken --output text --profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %})
+        if [ -z "$CI" ]; then
+            PROFILE_ARGS="--profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}"
+        else
+            PROFILE_ARGS=""
+        fi
+
+        # Check if AWS credentials are valid by trying to retrieve the caller identity.
+        # If the ARN is not returned, assume credentials are expired or not set correctly.
+        caller_identity=$(aws sts get-caller-identity --region={% endraw %}{{ aws_org_home_region }}{% raw %} $PROFILE_ARGS --query Arn --output text 2>/dev/null || echo "")
+        if [ -z "$caller_identity" ]; then
+            if [ -n "$CI" ]; then
+                echo "Error: In CI environment, aws sso login should never be called...something is wrong with this script or your workflow...perhaps you did not OIDC Auth yet in CI?"
+                exit 1
+            fi
+            echo "SSO credentials not found or expired, logging in..."
+            aws sso login $PROFILE_ARGS
+        else
+            echo "Using existing AWS credentials: $caller_identity"
+        fi
+
+        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+            --domain {% endraw %}{{ repo_org_name }}{% raw %} \
+            --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} \
+            --region {% endraw %}{{ aws_org_home_region }}{% raw %} \
+            --query authorizationToken \
+            --output text $PROFILE_ARGS)
     fi
 
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_USERNAME=aws

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -1,5 +1,5 @@
 {% if python_package_registry is defined and python_package_registry == "AWS CodeArtifact" %}{% raw %}#!/usr/bin/env bash
-set -e
+set -ex
 
 # If none of these are set we can't possibly continue and should fail so you can fix it
 if [ -z "$AWS_PROFILE" ] && [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
@@ -29,19 +29,23 @@ else
             echo "Using existing AWS credentials: $caller_identity"
         fi
 
+        set +x
         export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
             --domain {% endraw %}{{ repo_org_name }}{% raw %} \
             --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} \
             --region {% endraw %}{{ aws_org_home_region }}{% raw %} \
             --query authorizationToken \
             --output text $PROFILE_ARGS)
+        set -x
     fi
 
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_USERNAME=aws
-    echo "::add-mask::$UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD" # ensure this doesn't show up in the CI logs
+    set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    set -x
     export UV_INDEX_CODE_ARTIFACT_STAGING_USERNAME=aws
-    echo "::add-mask::$UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD" # ensure this doesn't show up in the CI logs
+    set +x
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    set -x
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -19,4 +19,4 @@ else
     export UV_INDEX_CODE_ARTIFACT_STAGING_USERNAME=aws
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
 
-fi{% endraw %}{% endif %}
+fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -1,0 +1,20 @@
+{% if python_package_registry is defined and python_package_registry == "AWS CodeArtifact" %}{% raw %}#!/usr/bin/env bash
+set -e
+
+# If none of these are set we can't possibly continue and should fail so you can fix it
+if [ -z "$AWS_PROFILE" ] && [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
+    echo "No AWS profile, access key, or auth token found, cannot proceed."
+    exit 1
+else
+    # Only regenerate the token if it doesn't exist or wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
+    if [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
+        echo "Fetching CodeArtifact token"
+        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain {% endraw %}{{ repo_org_name }}{% raw %} --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} --region {% endraw %}{{ aws_org_home_region }}{% raw %} --query authorizationToken --output text --profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %})
+    fi
+
+    export UV_INDEX_CODE_ARTIFACT_PRIMARY_USERNAME=aws
+    export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export UV_INDEX_CODE_ARTIFACT_STAGING_USERNAME=aws
+    export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+
+fi{% endraw %}{% endif %}

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -9,6 +9,8 @@ else
     # Only regenerate the token if it doesn't exist or wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
     if [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
         echo "Fetching CodeArtifact token"
+        # TODO: only re-login if the sso credentials have expired
+        aws sso login --profile={% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}
         export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain {% endraw %}{{ repo_org_name }}{% raw %} --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} --region {% endraw %}{{ aws_org_home_region }}{% raw %} --query authorizationToken --output text --profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %})
     fi
 

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -39,12 +39,8 @@ else
         set -x
     fi
 
-    export UV_INDEX_CODE_ARTIFACT_PRIMARY_USERNAME=aws
     set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
-    set -x
-    export UV_INDEX_CODE_ARTIFACT_STAGING_USERNAME=aws
-    set +x
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     set -x
 

--- a/template/template/.devcontainer/create-aws-profile.sh.jinja
+++ b/template/template/.devcontainer/create-aws-profile.sh.jinja
@@ -1,0 +1,1 @@
+../../.devcontainer/create-aws-profile.sh.jinja-base

--- a/template/template/.devcontainer/{% if not template_uses_pulumi %}create-aws-profile.sh{% endif %}
+++ b/template/template/.devcontainer/{% if not template_uses_pulumi %}create-aws-profile.sh{% endif %}
@@ -1,1 +1,0 @@
-../../../.devcontainer/create-aws-profile.sh

--- a/template/tests/copier_data/data1.yaml.jinja-base
+++ b/template/tests/copier_data/data1.yaml.jinja-base
@@ -5,6 +5,7 @@ description: Doing amazing things
 ssh_port_number: 12345
 use_windows_in_ci: false
 {% endraw %}{% if template_uses_python %}{% raw %}
+python_package_registry: PyPI
 aws_identity_center_id: d-9145c20053
 aws_org_home_region: us-west-2
 aws_production_account_id: 123456789012

--- a/template/tests/copier_data/data2.yaml.jinja-base
+++ b/template/tests/copier_data/data2.yaml.jinja-base
@@ -5,6 +5,7 @@ description: Doing crazy things! So many things!
 ssh_port_number: 54321
 use_windows_in_ci: true
 {% endraw %}{% if template_uses_python %}{% raw %}
+python_package_registry: AWS CodeArtifact
 aws_identity_center_id: d-9145c20053
 aws_org_home_region: us-east-1
 aws_production_account_id: 123456789012

--- a/template/tests/copier_data/data2.yaml.jinja-base
+++ b/template/tests/copier_data/data2.yaml.jinja-base
@@ -6,6 +6,7 @@ ssh_port_number: 54321
 use_windows_in_ci: true
 {% endraw %}{% if template_uses_python %}{% raw %}
 python_package_registry: AWS CodeArtifact
+aws_central_infrastructure_account_id: 012321432543
 aws_identity_center_id: d-9145c20053
 aws_org_home_region: us-east-1
 aws_production_account_id: 123456789012

--- a/template/tests/copier_data/data2.yaml.jinja-base
+++ b/template/tests/copier_data/data2.yaml.jinja-base
@@ -7,6 +7,7 @@ use_windows_in_ci: true
 {% endraw %}{% if template_uses_python %}{% raw %}
 python_package_registry: AWS CodeArtifact
 aws_central_infrastructure_account_id: 012321432543
+core_infra_base_access_profile_name: MyAccessRole
 aws_identity_center_id: d-9145c20053
 aws_org_home_region: us-east-1
 aws_production_account_id: 123456789012


### PR DESCRIPTION
 ## Why is this change necessary?
Need to have grandchild repos be able to install dependencies from AWS CodeArtifact


 ## How does this change address the issue?
Updated the create-aws-profile.sh script to include some more things by default, and made it Jinja so that it was more configurable.

Added a script to authenticate into CodeArtifact.  it's still a bit annoying because if you want the environmental variables for uv to persist in your environment (so you could do a `uv lock` on your own) you have to run it via source...not sure the best way to work around that....uv doesn't seem to have a command to update a config like poetry did



 ## What side effects does this change have?
None


 ## How is this change tested?
In many downstream repos. python-template and aws-central infra child repos. Grandchild repos: cloud courier, ephemeral pulumi deploy, and a private repo that installed from codeartifact. CI and local development was tested.


 ## Other
Made the devcontainer startup not fail if there wasn't a uv lock file.  This should make it easier to instantiate new repos (in case you forget to create the lock file initially).