### PR TITLE
Publish to code artifact

### DIFF
--- a/extensions/context.py
+++ b/extensions/context.py
@@ -33,6 +33,7 @@ class ContextUpdater(ContextHook):
         context["ephemeral_pulumi_deploy_version"] = "0.0.2"
         context["pydantic_version"] = "2.10.6"
         context["pyinstaller_version"] = "6.12.0"
+        context["setuptools_version"] = "76.0.0"
         # These are duplicated in the CI files for this repository
         context["gha_checkout"] = "v4.2.2"
         context["gha_setup_python"] = "v5.4.0"

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -109,8 +109,8 @@ jobs:
 
       - name: install new dependencies
         env:
+          # Provide a fake token so it doesn't attempt to access AWS to generate a new one when the script is run if CodeArtifact is set as the registry
           CODEARTIFACT_AUTH_TOKEN: 'faketoken'
-          UV_NO_CACHE: 'true'
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
           python $RUNNER_TEMP/replace_private_package_registries.py

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -28,6 +28,7 @@ class ContextUpdater(ContextHook):
         context["ephemeral_pulumi_deploy_version"] = "{{ ephemeral_pulumi_deploy_version }}"
         context["pydantic_version"] = "{{ pydantic_version }}"
         context["pyinstaller_version"] = "{{ pyinstaller_version }}"
+        context["setuptools_version"] = "{{ setuptools_version }}"
 
         context["gha_checkout"] = "{{ gha_checkout }}"
         context["gha_setup_python"] = "{{ gha_setup_python }}"

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -38,12 +38,12 @@ else
             --output text $PROFILE_ARGS)
         set -x
     fi
-
+    # uv sometimes uses has better luck when setting the twine env vars
+    export TWINE_USERNAME=aws
     set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
-    export UV_INDEX_CODE_ARTIFACT_PRIMARY_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export TWINE_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
-    export UV_INDEX_CODE_ARTIFACT_STAGING_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     set -x
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -6,7 +6,7 @@ if [ -z "$AWS_PROFILE" ] && [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$CODEARTIFACT_A
     echo "No AWS profile, access key, or auth token found, cannot proceed."
     exit 1
 else
-    # Only regenerate the token if it doesn't exist or wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
+    # Only regenerate the token if it wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
     if [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
         echo "Fetching CodeArtifact token"
         if [ -z "$CI" ]; then
@@ -30,7 +30,7 @@ else
         fi
 
         set +x
-        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
             --domain {% endraw %}{{ repo_org_name }}{% raw %} \
             --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} \
             --region {% endraw %}{{ aws_org_home_region }}{% raw %} \

--- a/template/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -41,7 +41,9 @@ else
 
     set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export UV_INDEX_CODE_ARTIFACT_PRIMARY_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export UV_INDEX_CODE_ARTIFACT_STAGING_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     set -x
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}


### PR DESCRIPTION
 ## Why is this change necessary?
Need to be able to publish to code artifact


 ## How does this change address the issue?
Updates the codeartifact auth script to include those envvars that are needed


 ## What side effects does this change have?
None


 ## How is this change tested?
In downstream child and grandchild templates that confirmed publishing works
