### PR TITLE
Setup node

### DIFF
--- a/extensions/context.py
+++ b/extensions/context.py
@@ -17,6 +17,7 @@ class ContextUpdater(ContextHook):
         context["copier_version"] = "9.5.0"
         context["copier_templates_extension_version"] = "0.3.0"
         #######
+        context["pnpm_version"] = "10.6.3"
         # These are duplicated in the pyproject.toml of this repository
         context["pyright_version"] = "1.1.396"
         context["pytest_version"] = "8.3.4"
@@ -41,6 +42,7 @@ class ContextUpdater(ContextHook):
         #######
         context["gha_upload_artifact"] = "v4.6.1"
         context["gha_configure_aws_credentials"] = "v4.1.0"
+        context["gha_setup_node"] = "v4.2.2"
         context["gha_mutex"] = "1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10"
         context["gha_linux_runner"] = "ubuntu-24.04"
         # These also in the tests/data.yml files in this repository and in copier.yaml

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -42,7 +42,7 @@ class ContextUpdater(ContextHook):
         #######
         context["gha_upload_artifact"] = "v4.6.1"
         context["gha_configure_aws_credentials"] = "v4.1.0"
-        context["gha_setup_node"] = "v4.2.2"
+        context["gha_setup_node"] = "v4.3.0"
         context["gha_mutex"] = "1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10"
         context["gha_linux_runner"] = "ubuntu-24.04"
         # These also in the tests/data.yml files in this repository and in copier.yaml

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -2,7 +2,7 @@
 # can pass in the full major.minor.patch version of python as an optional argument
 set -ex
 
-{% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
+{% endraw %}{% if template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
 npm -v
 npm install -g pnpm@{% endraw %}{{ pnpm_version }}
 pnpm -v{% endraw %}{% endif %}{% raw %}

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -4,7 +4,7 @@ set -ex
 
 {% endraw %}{% if template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
 npm -v
-npm install -g pnpm@{% endraw %}{{ pnpm_version }}
+npm install -g pnpm@{% endraw %}{{ pnpm_version }}{% raw %}
 pnpm -v{% endraw %}{% endif %}{% raw %}
 
 curl -LsSf https://astral.sh/uv/{% endraw %}{{ uv_version }}{% raw %}/install.sh | sh

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -2,6 +2,11 @@
 # can pass in the full major.minor.patch version of python as an optional argument
 set -ex
 
+{% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
+npm -v
+npm install -g pnpm@{% endraw %}{{ pnpm_version }}
+pnpm -v{% endraw %}{% endif %}{% raw %}
+
 curl -LsSf https://astral.sh/uv/{% endraw %}{{ uv_version }}{% raw %}/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -22,12 +22,19 @@ jobs:
         os:
           - "{% endraw %}{{ gha_linux_runner }}{% raw %}"
         python-version:
-            - {% endraw %}{{ python_version }}{% raw %}
+            - {% endraw %}{{ python_version }}{% raw %}{% endraw %}{% if template_uses_javascript %}{% raw %}
+        node-version:
+            - 22.14.0{% endraw %}{% endif %}{% raw %}
     name: Pre-commit for Py${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+
+{% endraw %}{% if template_uses_javascript %}{% raw %}      - name: Setup node
+        uses: actions/setup-node@{% endraw %}{{ gha_setup_node }}{% raw %}
+        with:
+          node-version: ${{ matrix.node-version }}{% endraw %}{% endif %}{% raw %}
 
       - name: Install latest versions of python packages
         uses: ./.github/actions/install_deps_uv

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -11,6 +11,7 @@ class ContextUpdater(ContextHook):
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:{% endraw %}
         context["uv_version"] = "{{ uv_version }}"
+        context["pnpm_version"] = "{{ pnpm_version }}"
         context["pre_commit_version"] = "{{ pre_commit_version }}"
         context["pyright_version"] = "{{ pyright_version }}"
         context["pytest_version"] = "{{ pytest_version }}"
@@ -35,6 +36,7 @@ class ContextUpdater(ContextHook):
         context["gha_cache"] = "{{ gha_cache }}"
         context["gha_upload_artifact"] = "{{ gha_upload_artifact }}"
         context["gha_configure_aws_credentials"] = "{{ gha_configure_aws_credentials }}"
+        context["gha_setup_node"] = "{{ gha_setup_node }}"
         context["gha_mutex"] = "{{ gha_mutex }}"
         context["gha_linux_runner"] = "{{ gha_linux_runner }}"
         context["gha_windows_runner"] = "{{ gha_windows_runner }}"


### PR DESCRIPTION
 ## Why is this change necessary?
Need to be able to install node dependencies in CI


 ## How does this change address the issue?
Add gha setup-node.  Install pnpm as part of CI tooling. start process of changing pnpm to just be baseline tooling instead of per-project specification of version.


 ## What side effects does this change have?
None


 ## How is this change tested?
downstream https://github.com/LabAutomationAndScreening/copier-nuxt-python-intranet-app and grandchild repo
