### PR TITLE
Pylint fix and windows host helper

### DIFF
--- a/.devcontainer/windows-host-helper.sh
+++ b/.devcontainer/windows-host-helper.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# If you are using a Windows host and you initially cloned the repository directly onto your hard drive, you may run into file permission issues when running copier updates. To avoid these, after initially building the devcontainer, run this from the repo root:
+# cp .devcontainer/windows-host-helper.sh ../
+# cd ..
+# bash windows-host-helper.sh <git-url>
+
+# If you're still having issues, make sure in Windows Developer Settings that you enabled Developer Mode, and also that you set your git config to have `core.autocrlf=false` and `core.symlinks=true` globally
+
+set -e  # Exit immediately on error
+
+if [ -z "$BASH_VERSION" ]; then
+  echo "Error: This script must be run with bash (e.g., 'bash windows-host-helper.sh')." >&2
+  exit 1
+fi
+
+# Check for the git URL argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <git-url>"
+    exit 1
+fi
+
+gitUrl="$1"
+
+# Extract repository name (removes .git suffix if present)
+repoName=$(basename "$gitUrl" .git)
+
+echo "Repo name extracted as '$repoName'"
+
+# Remove any existing subfolder with the repository name and recreate it
+rm -rf "./$repoName" || true # sometimes deleting the .venv folder fails
+rm -rf "./$repoName/*.md" # for some reason, sometimes md files are left behind
+mkdir -p "./$repoName"
+
+# Create a temporary directory for cloning
+tmpdir=$(mktemp -d)
+
+# Clone the repository into a subfolder inside the temporary directory.
+# This creates "$tmpdir/$repoName" with the repository's contents.
+git clone "$gitUrl" "$tmpdir/$repoName"
+
+# Enable dotglob so that '*' includes hidden files
+shopt -s dotglob
+
+# Move all contents (including hidden files) from the cloned repo to the target folder
+mv "$tmpdir/$repoName"/* "./$repoName/"
+
+# Clean up: remove the temporary directory
+rm -rf "$tmpdir"
+
+echo "Repository '$repoName' has been updated."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,7 +191,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: aaab3ccb541532d2bcdf0410ab93ff4fafc266f5 # frozen: v3.3.5
+    rev: 88543500c70e3aa303b6c0861e2a7a006673f6a8
     hooks:
       - id: pylint
         name: pylint

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -19,7 +19,7 @@ class ContextUpdater(ContextHook):
         #######
         context["pnpm_version"] = "10.6.3"
         # These are duplicated in the pyproject.toml of this repository
-        context["pyright_version"] = "1.1.396"
+        context["pyright_version"] = "1.1.397"
         context["pytest_version"] = "8.3.4"
         context["pytest_randomly_version"] = "3.16.0"
         context["pytest_cov_version"] = "6.0.0"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -42,17 +42,23 @@ class ContextUpdater(ContextHook):
         context["gha_checkout"] = "v4.2.2"
         context["gha_setup_python"] = "v5.4.0"
         context["gha_cache"] = "v4.2.2"
+        context["gha_linux_runner"] = "ubuntu-24.04"
         #######
-        context["gha_upload_artifact"] = "v4.6.1"
+        context["gha_upload_artifact"] = "v4.6.2"
+        context["gha_download_artifact"] = "v4.2.1"
+        context["gha_setup_buildx"] = "v3.10.0"
+        context["gha_docker_build_push"] = "v6.15.0"
         context["gha_configure_aws_credentials"] = "v4.1.0"
         context["gha_setup_node"] = "v4.3.0"
         context["gha_mutex"] = "1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10"
-        context["gha_linux_runner"] = "ubuntu-24.04"
+        context["gha_windows_runner"] = "windows-2022"
+        #######
+        context["debian_release_name"] = "bookworm"
+        context["alpine_image_version"] = "3.20"
         # These also in the tests/data.yml files in this repository and in copier.yaml
         context["py312_version"] = "3.12.7"  # ReadTheDocs does not yet support 3.12.8
         context["py313_version"] = "3.13.2"
         #######
-        context["gha_windows_runner"] = "windows-2022"
         # Kludge to allow for the same docker-compose file in child and grandchild templates
         context["aws_region_for_stack"] = "us-east-1"
         # Kludge to be able to stop symlinked jinja files from being updated in child templates when the variable is really meant for the instantiated grandchild template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
     "pytest-randomly>=3.16.0",
-    "pyright[nodejs]>=1.1.396",
+    "pyright[nodejs]>=1.1.397",
     "copier>=9",
     "copier-templates-extensions>=0.3.0"
 ]

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -40,6 +40,9 @@
 {% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_vuejs is defined and template_uses_vuejs is sameas(true) %}{% raw %}
         // VueJS
         "vue.volar@2.2.8",
+{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
+        // All javascript
+        "dbaeumer.vscode-eslint@3.0.13",
 {% endraw %}{% endif %}{% raw %}
 
         // Misc file formats

--- a/template/.devcontainer/windows-host-helper.sh
+++ b/template/.devcontainer/windows-host-helper.sh
@@ -1,0 +1,1 @@
+../../.devcontainer/windows-host-helper.sh

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -38,6 +38,9 @@ class ContextUpdater(ContextHook):
         context["gha_setup_python"] = "{{ gha_setup_python }}"
         context["gha_cache"] = "{{ gha_cache }}"
         context["gha_upload_artifact"] = "{{ gha_upload_artifact }}"
+        context["gha_download_artifact"] = "{{ gha_download_artifact }}"
+        context["gha_setup_buildx"] = "{{ gha_setup_buildx }}"
+        context["gha_docker_build_push"] = "{{ gha_docker_build_push }}"
         context["gha_configure_aws_credentials"] = "{{ gha_configure_aws_credentials }}"
         context["gha_setup_node"] = "{{ gha_setup_node }}"
         context["gha_mutex"] = "{{ gha_mutex }}"
@@ -47,6 +50,9 @@ class ContextUpdater(ContextHook):
         context["py311_version"] = "{{ py311_version }}"
         context["py312_version"] = "{{ py312_version }}"
         context["py313_version"] = "{{ py313_version }}"
+
+        context["debian_release_name"] = "{{ debian_release_name }}"
+        context["alpine_image_version"] = "{{ alpine_image_version }}"
 
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = {{ "True" if template_uses_vuejs else "False" }}

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -59,7 +60,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = ">=9" },
     { name = "copier-templates-extensions", specifier = ">=0.3.0" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.396" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.397" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
@@ -347,15 +348,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.396"
+version = "1.1.397"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/73/f20cb1dea1bdc1774e7f860fb69dc0718c7d8dea854a345faec845eb086a/pyright-1.1.396.tar.gz", hash = "sha256:142901f5908f5a0895be3d3befcc18bedcdb8cc1798deecaec86ef7233a29b03", size = 3814400 }
+sdist = { url = "https://files.pythonhosted.org/packages/92/23/cefa10c9cb198e0858ed0b9233371d62bca880337f628e58f50dfdfb12f0/pyright-1.1.397.tar.gz", hash = "sha256:07530fd65a449e4b0b28dceef14be0d8e0995a7a5b1bb2f3f897c3e548451ce3", size = 3818998 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/be/ecb7cfb42d242b7ee764b52e6ff4782beeec00e3b943a3ec832b281f9da6/pyright-1.1.396-py3-none-any.whl", hash = "sha256:c635e473095b9138c471abccca22b9fedbe63858e0b40d4fc4b67da041891844", size = 5689355 },
+    { url = "https://files.pythonhosted.org/packages/01/b5/98ec41e1e0ad5576ecd42c90ec363560f7b389a441722ea3c7207682dec7/pyright-1.1.397-py3-none-any.whl", hash = "sha256:2e93fba776e714a82b085d68f8345b01f91ba43e1ab9d513e79b70fc85906257", size = 5693631 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
 ## Link to Issue or Slack thread
https://github.com/pylint-dev/pylint/pull/10289


 ## Why is this change necessary?
pylint pre-commit hook was erroring on install

Trying to run copier updates in devcontainers on windows hosts was sometimes having issues


 ## How does this change address the issue?
Pins a patched version of pylint

Creates a helper script that can be run to reclone all the files inside the devcontainer on a windows host.


 ## What side effects does this change have?
None


 ## How is this change tested?
In several child and grandchild repositories


 ## Other
Added some misc versions to context.py