### PR TITLE
Remove `version` from docker-compose.yaml

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   devcontainer:
     build: .

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -38,6 +38,11 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = "0.262.5"
         context["fastapi_version"] = "0.115.11"
         context["uvicorn_version"] = "0.34.0"
+        #######
+        context["nuxt_ui_version"] = "^3.0.0"
+        context["nuxt_version"] = "^3.16.0"
+        context["typescript_version"] = "^5.8.2"
+        #######
         # These are duplicated in the CI files for this repository
         context["gha_checkout"] = "v4.2.2"
         context["gha_setup_python"] = "v5.4.0"

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -40,6 +40,7 @@
 {% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_vuejs is defined and template_uses_vuejs is sameas(true) %}{% raw %}
         // VueJS
         "vue.volar@2.2.8",
+        "vitest.explorer@1.16.1",
 {% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
         // All javascript
         "dbaeumer.vscode-eslint@3.0.13",

--- a/template/.devcontainer/docker-compose.yml.jinja-base
+++ b/template/.devcontainer/docker-compose.yml.jinja-base
@@ -1,5 +1,4 @@
-{% raw %}version: '3.8'
-services:
+{% raw %}services:
   devcontainer:
     build:
       context: .

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -34,6 +34,10 @@ class ContextUpdater(ContextHook):
         context["fastapi_version"] = "{{ fastapi_version }}"
         context["uvicorn_version"] = "{{ uvicorn_version }}"
 
+        context["nuxt_ui_version"] = "{{ nuxt_ui_version }}"
+        context["nuxt_version"] = "{{ nuxt_version }}"
+        context["typescript_version"] = "{{ typescript_version }}"
+
         context["gha_checkout"] = "{{ gha_checkout }}"
         context["gha_setup_python"] = "{{ gha_setup_python }}"
         context["gha_cache"] = "{{ gha_cache }}"


### PR DESCRIPTION
 ## Why is this change necessary?
It's been deprecated


 ## How does this change address the issue?
Removes it


 ## What side effects does this change have?
None


 ## How is this change tested?
downstream repos

 ## Other
Added some js libraries to context