### PR TITLE
Allow SSM Port Forwarding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,7 +179,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 99abe27a5a16f301d9e0a3828181399dfbf54ebd # frozen: v0.11.0
+    rev: 25a8c8da6c24a3b9a1a536e2674683dd0eead5d6  # frozen: v0.11.2
     hooks:
       - id: ruff
         name: ruff-src
@@ -192,7 +192,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: 88543500c70e3aa303b6c0861e2a7a006673f6a8
+    rev: 7ac5a4d4f77576df3a00e63f86ca86e0e1780b47  # frozen: v3.3.6
     hooks:
       - id: pylint
         name: pylint

--- a/copier.yaml
+++ b/copier.yaml
@@ -50,6 +50,11 @@ template_uses_vuejs:
     default: no
     when: "{{ template_uses_javascript }}"
 
+install_aws_ssm_port_forwarding_plugin:
+    type: bool
+    help: Is this template for something that will want the AWS SSM Port Forwarding plugin be installed?
+    default: no
+
 
 _min_copier_version: "9.4"
 

--- a/copier.yaml
+++ b/copier.yaml
@@ -50,9 +50,9 @@ template_uses_vuejs:
     default: no
     when: "{{ template_uses_javascript }}"
 
-install_aws_ssm_port_forwarding_plugin:
+template_might_want_to_install_aws_ssm_port_forwarding_plugin:
     type: bool
-    help: Is this template for something that will want the AWS SSM Port Forwarding plugin be installed?
+    help: Is this template for something that might want the AWS SSM Port Forwarding plugin be installed?
     default: no
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 # Settings managed by the base template
 norecursedirs = node_modules .precommit_cache .npm_cache .pipenv_cache venv .venv .history
-addopts = --cov=src --cov-report html --cov-report term-missing:skip-covered
+addopts = --cov=src --cov-report html --cov-report term-missing:skip-covered --cov-config=./.coveragerc
 
 log_cli = 1
 log_cli_level = INFO

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -2,6 +2,10 @@
 # can pass in the full major.minor.patch version of python as an optional argument
 set -ex
 
+{% endraw %}{% if is_child_of_copier_base_template is not defined and install_aws_ssm_port_forwarding_plugin is defined and install_aws_ssm_port_forwarding_plugin is sameas(true) %}{% raw %}
+curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "/tmp/session-manager-plugin.deb"
+sudo dpkg -i /tmp/session-manager-plugin.deb{% endraw %}{% endif %}{% raw %}
+
 {% endraw %}{% if template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
 npm -v
 npm install -g pnpm@{% endraw %}{{ pnpm_version }}{% raw %}

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -3,6 +3,7 @@
 set -ex
 
 {% endraw %}{% if is_child_of_copier_base_template is not defined and install_aws_ssm_port_forwarding_plugin is defined and install_aws_ssm_port_forwarding_plugin is sameas(true) %}{% raw %}
+# TODO: figure out how to pin this
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "/tmp/session-manager-plugin.deb"
 sudo dpkg -i /tmp/session-manager-plugin.deb{% endraw %}{% endif %}{% raw %}
 

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -6,7 +6,8 @@ set -ex
 # Based on https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-debian-and-ubuntu.html
 # TODO: figure out how to pin this
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "/tmp/session-manager-plugin.deb"
-sudo dpkg -i /tmp/session-manager-plugin.deb{% endraw %}{% endif %}{% raw %}
+sudo dpkg -i /tmp/session-manager-plugin.deb
+session-manager-plugin --version{% endraw %}{% endif %}{% raw %}
 
 {% endraw %}{% if template_uses_javascript is defined and template_uses_javascript is sameas(true) %}{% raw %}
 npm -v

--- a/template/.devcontainer/install-ci-tooling.sh.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja-base
@@ -3,6 +3,7 @@
 set -ex
 
 {% endraw %}{% if is_child_of_copier_base_template is not defined and install_aws_ssm_port_forwarding_plugin is defined and install_aws_ssm_port_forwarding_plugin is sameas(true) %}{% raw %}
+# Based on https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-debian-and-ubuntu.html
 # TODO: figure out how to pin this
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "/tmp/session-manager-plugin.deb"
 sudo dpkg -i /tmp/session-manager-plugin.deb{% endraw %}{% endif %}{% raw %}

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -36,7 +36,11 @@ pnpm_version:
     help: What version of pnpm is used for development?
     default: 10.6.3
 
-{% endraw %}{% endif %}{% raw %}
+{% endraw %}{% endif %}{% raw %}{% endraw %}{% if template_might_want_to_install_aws_ssm_port_forwarding_plugin %}{% raw %}
+install_aws_ssm_port_forwarding_plugin:
+    type: bool
+    help: Should the AWS SSM Port Forwarding Plugin be installed?
+    default: no{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_python %}
 python_version:
     type: str

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -62,4 +62,5 @@ class ContextUpdater(ContextHook):
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = {{ "True" if template_uses_vuejs else "False" }}
         context["template_uses_javascript"] = {{ "True" if template_uses_javascript else "False" }}
+        context["install_aws_ssm_port_forwarding_plugin"] = {{ "True if install_aws_ssm_port_forwarding_plugin else "False" }}
         return context

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -62,5 +62,4 @@ class ContextUpdater(ContextHook):
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = {{ "True" if template_uses_vuejs else "False" }}
         context["template_uses_javascript"] = {{ "True" if template_uses_javascript else "False" }}
-        context["install_aws_ssm_port_forwarding_plugin"] = {{ "True" if install_aws_ssm_port_forwarding_plugin else "False" }}
         return context

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -62,5 +62,5 @@ class ContextUpdater(ContextHook):
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = {{ "True" if template_uses_vuejs else "False" }}
         context["template_uses_javascript"] = {{ "True" if template_uses_javascript else "False" }}
-        context["install_aws_ssm_port_forwarding_plugin"] = {{ "True if install_aws_ssm_port_forwarding_plugin else "False" }}
+        context["install_aws_ssm_port_forwarding_plugin"] = {{ "True" if install_aws_ssm_port_forwarding_plugin else "False" }}
         return context

--- a/template/tests/copier_data/data1.yaml.jinja-base
+++ b/template/tests/copier_data/data1.yaml.jinja-base
@@ -5,6 +5,7 @@ is_open_source: true
 description: Doing amazing things
 ssh_port_number: 12345
 use_windows_in_ci: false
+{% endraw %}{% if template_might_want_to_install_aws_ssm_port_forwarding_plugin %}{% raw %}install_aws_ssm_port_forwarding_plugin: true{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_javascript %}{% raw %}
 node_version: 22.13.0
 pnpm_version: 9.15.4{% endraw %}{% endif %}{% raw %}

--- a/template/tests/copier_data/data2.yaml.jinja-base
+++ b/template/tests/copier_data/data2.yaml.jinja-base
@@ -5,6 +5,7 @@ is_open_source: false
 description: Doing crazy things! So many things!
 ssh_port_number: 54321
 use_windows_in_ci: true
+{% endraw %}{% if template_might_want_to_install_aws_ssm_port_forwarding_plugin %}{% raw %}install_aws_ssm_port_forwarding_plugin: false{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_javascript %}{% raw %}
 node_version: 22.14.0
 pnpm_version: 10.6.3{% endraw %}{% endif %}{% raw %}

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -8,4 +8,4 @@ template_uses_pulumi: true
 repo_org_name: theGreatestOrg
 template_uses_javascript: false
 template_uses_vuejs: false
-install_aws_ssm_port_forwarding_plugin: true
+template_might_want_to_install_aws_ssm_port_forwarding_plugin: true

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -8,3 +8,4 @@ template_uses_pulumi: true
 repo_org_name: theGreatestOrg
 template_uses_javascript: false
 template_uses_vuejs: false
+install_aws_ssm_port_forwarding_plugin: true

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -9,3 +9,4 @@ template_uses_pulumi: false
 repo_org_name: Initech
 template_uses_javascript: true
 template_uses_vuejs: true
+install_aws_ssm_port_forwarding_plugin: false

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -9,4 +9,4 @@ template_uses_pulumi: false
 repo_org_name: Initech
 template_uses_javascript: true
 template_uses_vuejs: true
-install_aws_ssm_port_forwarding_plugin: false
+template_might_want_to_install_aws_ssm_port_forwarding_plugin: false


### PR DESCRIPTION
 ## Why is this change necessary?
Allow using SSM Port Forwarding


 ## How does this change address the issue?
Install necessary dependencies to use AWS SSM Port forwarding when warranted


 ## What side effects does this change have?
None


 ## How is this change tested?
copier-python-package-template which doesn't want to use this (and downstream repo), and copier-nuxt-intranet which does (and downstream repo)


 ## Other
Also bumped some pre-commit hooks and explicitly specified .coveragerc location