### PR TITLE
Bump context versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
   - repo: https://github.com/crate-ci/typos
-    rev: 2300ad1b6b5c37da54bcafb1a06211196503eac9 # frozen: v1
+    rev: 0ebd3e2da3cef03102eb36b1f930b7961c1adfd4  # frozen: v1
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -19,14 +19,14 @@ class ContextUpdater(ContextHook):
         #######
         context["pnpm_version"] = "10.6.3"
         # These are duplicated in the pyproject.toml of this repository
-        context["pyright_version"] = "1.1.397"
-        context["pytest_version"] = "8.3.4"
+        context["pyright_version"] = "1.1.398"
+        context["pytest_version"] = "8.3.5"
         context["pytest_randomly_version"] = "3.16.0"
         context["pytest_cov_version"] = "6.0.0"
         #######
         context["sphinx_version"] = "8.1.3"
-        context["pulumi_version"] = "3.156.0"
-        context["pulumi_aws_version"] = "6.72.0"
+        context["pulumi_version"] = "3.159.0"
+        context["pulumi_aws_version"] = "6.74.0"
         context["pulumi_aws_native_version"] = "1.26.0"
         context["pulumi_command_version"] = "1.0.2"
         context["pulumi_github"] = "6.7.0"
@@ -38,6 +38,7 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = "0.262.5"
         context["fastapi_version"] = "0.115.11"
         context["uvicorn_version"] = "0.34.0"
+        context["lab_auto_pulumi_version"] = "0.1.0"
         #######
         context["nuxt_ui_version"] = "^3.0.0"
         context["nuxt_version"] = "^3.16.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "pytest>=8.3.4",
+    "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
     "pytest-randomly>=3.16.0",
-    "pyright[nodejs]>=1.1.397",
+    "pyright[nodejs]>=1.1.398",
     "copier>=9",
     "copier-templates-extensions>=0.3.0"
 ]

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -33,6 +33,7 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = "{{ strawberry_graphql_version }}"
         context["fastapi_version"] = "{{ fastapi_version }}"
         context["uvicorn_version"] = "{{ uvicorn_version }}"
+        context["lab_auto_pulumi_version"] = "{{ lab_auto_pulumi_version }}"
 
         context["nuxt_ui_version"] = "{{ nuxt_ui_version }}"
         context["nuxt_version"] = "{{ nuxt_version }}"

--- a/uv.lock
+++ b/uv.lock
@@ -60,8 +60,8 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = ">=9" },
     { name = "copier-templates-extensions", specifier = ">=0.3.0" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.397" },
-    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.398" },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
 ]
@@ -348,15 +348,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.397"
+version = "1.1.398"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/23/cefa10c9cb198e0858ed0b9233371d62bca880337f628e58f50dfdfb12f0/pyright-1.1.397.tar.gz", hash = "sha256:07530fd65a449e4b0b28dceef14be0d8e0995a7a5b1bb2f3f897c3e548451ce3", size = 3818998 }
+sdist = { url = "https://files.pythonhosted.org/packages/24/d6/48740f1d029e9fc4194880d1ad03dcf0ba3a8f802e0e166b8f63350b3584/pyright-1.1.398.tar.gz", hash = "sha256:357a13edd9be8082dc73be51190913e475fa41a6efb6ec0d4b7aab3bc11638d8", size = 3892675 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/b5/98ec41e1e0ad5576ecd42c90ec363560f7b389a441722ea3c7207682dec7/pyright-1.1.397-py3-none-any.whl", hash = "sha256:2e93fba776e714a82b085d68f8345b01f91ba43e1ab9d513e79b70fc85906257", size = 5693631 },
+    { url = "https://files.pythonhosted.org/packages/58/e0/5283593f61b3c525d6d7e94cfb6b3ded20b3df66e953acaf7bb4f23b3f6e/pyright-1.1.398-py3-none-any.whl", hash = "sha256:0a70bfd007d9ea7de1cf9740e1ad1a40a122592cfe22a3f6791b06162ad08753", size = 5780235 },
 ]
 
 [package.optional-dependencies]
@@ -366,7 +366,7 @@ nodejs = [
 
 [[package]]
 name = "pytest"
-version = "8.3.4"
+version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -374,9 +374,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Why is this change necessary?
Bump some package versions


 ## How is this change tested?
copier-aws-central-infra
