### PR TITLE
ECR Image Push workflow

### DIFF
--- a/extensions/context.py
+++ b/extensions/context.py
@@ -19,15 +19,15 @@ class ContextUpdater(ContextHook):
         #######
         context["pnpm_version"] = "10.7.0"
         # These are duplicated in the pyproject.toml of this repository
-        context["pyright_version"] = "1.1.398"
+        context["pyright_version"] = "1.1.399"
         context["pytest_version"] = "8.3.5"
         context["pytest_randomly_version"] = "3.16.0"
         context["pytest_cov_version"] = "6.0.0"
         #######
         context["sphinx_version"] = "8.1.3"
-        context["pulumi_version"] = "3.160.0"
-        context["pulumi_aws_version"] = "6.74.0"
-        context["pulumi_aws_native_version"] = "1.26.0"
+        context["pulumi_version"] = "3.162.0"
+        context["pulumi_aws_version"] = "6.77.0"
+        context["pulumi_aws_native_version"] = "1.27.0"
         context["pulumi_command_version"] = "1.0.2"
         context["pulumi_github"] = "6.7.0"
         context["boto3_version"] = "1.37.11"
@@ -35,10 +35,10 @@ class ContextUpdater(ContextHook):
         context["pydantic_version"] = "2.11.1"
         context["pyinstaller_version"] = "6.12.0"
         context["setuptools_version"] = "76.0.0"
-        context["strawberry_graphql_version"] = "0.262.5"
+        context["strawberry_graphql_version"] = "0.264.0"
         context["fastapi_version"] = "0.115.12"
         context["uvicorn_version"] = "0.34.0"
-        context["lab_auto_pulumi_version"] = "0.1.6"
+        context["lab_auto_pulumi_version"] = "0.1.8"
         #######
         context["nuxt_ui_version"] = "^3.0.0"
         context["nuxt_version"] = "^3.16.0"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -40,8 +40,8 @@ class ContextUpdater(ContextHook):
         context["uvicorn_version"] = "0.34.0"
         context["lab_auto_pulumi_version"] = "0.1.8"
         #######
-        context["nuxt_ui_version"] = "^3.0.0"
-        context["nuxt_version"] = "^3.16.0"
+        context["nuxt_ui_version"] = "^3.0.2"
+        context["nuxt_version"] = "^3.16.2"
         context["typescript_version"] = "^5.8.2"
         #######
         # These are duplicated in the CI files for this repository

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -17,7 +17,7 @@ class ContextUpdater(ContextHook):
         context["copier_version"] = "9.6.0"
         context["copier_templates_extension_version"] = "0.3.0"
         #######
-        context["pnpm_version"] = "10.7.0"
+        context["pnpm_version"] = "10.8.1"
         # These are duplicated in the pyproject.toml of this repository
         context["pyright_version"] = "1.1.399"
         context["pytest_version"] = "8.3.5"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -56,10 +56,11 @@ class ContextUpdater(ContextHook):
         context["buildx_version"] = "v0.22.0"
         context["gha_docker_build_push"] = "v6.15.0"
         context["gha_configure_aws_credentials"] = "v4.1.0"
+        context["gha_amazon_ecr_login"] = "v2.0.1"
         context["gha_setup_node"] = "v4.3.0"
         context["gha_action_gh_release"] = "v2.2.1"
         context["gha_mutex"] = "1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10"
-        context["gha_windows_runner"] = "windows-2022"
+        context["gha_windows_runner"] = "windows-2025"
         #######
         context["debian_release_name"] = "bookworm"
         context["alpine_image_version"] = "3.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
     "pytest-randomly>=3.16.0",
-    "pyright[nodejs]>=1.1.398",
+    "pyright[nodejs]>=1.1.399",
     "copier>=9.6.0",
     "copier-templates-extensions>=0.3.0"
 ]

--- a/src/hash_git_files.py
+++ b/src/hash_git_files.py
@@ -1,0 +1,80 @@
+"""Used typically to calculate if all the files in the context of building a Docker image have changed or not."""
+
+import argparse
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+
+def get_tracked_files(repo_path: Path) -> list[str]:
+    """Return a list of files tracked by Git in the given repository folder, using the 'git ls-files' command."""
+    try:
+        result = subprocess.run(  # noqa: S603 # there's no concern about executing untrusted input, only we will call this script
+            ["git", "-C", str(repo_path), "ls-files"],  # noqa: S607 # yes, this is not using a complete executable path, but it's just git and git should always be present in PATH
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.splitlines()
+
+    except subprocess.CalledProcessError:
+        print("Error: The directory does not appear to be a Git repository or Git is not installed.", file=sys.stderr)  # noqa: T201 # this just runs as a simple script, so using print instead of log
+        sys.exit(1)
+
+
+def compute_adler32(repo_path: Path, files: list[str]) -> int:
+    """Compute an overall Adler-32 checksum of the provided files.
+
+    The checksum incorporates both the file names and their contents. Files are processed in sorted order to ensure consistent ordering.
+    """
+    checksum = 1  # Adler-32 default starting value
+
+    for file in sorted(files):
+        file_path = repo_path / file  # Use pathlib to combine paths
+        # Update the checksum with the file name (encoded as bytes)
+        checksum = zlib.adler32(file.encode("utf-8"), checksum)
+        try:
+            with file_path.open("rb") as f:
+                while True:
+                    chunk = f.read(4096)
+                    if not chunk:
+                        break
+                    checksum = zlib.adler32(chunk, checksum)
+        except Exception as e:
+            print(f"Error reading file {file}: {e}", file=sys.stderr)  # noqa: T201 # this just runs as a simple script, so using print instead of log
+            raise
+
+    return checksum
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute an Adler-32 checksum of all Git-tracked files in the specified folder."
+    )
+    _ = parser.add_argument("folder", type=Path, help="Path to the Git repository folder")
+    _ = parser.add_argument("--debug", action="store_true", help="Print all discovered Git-tracked files")
+    args = parser.parse_args()
+
+    repo_path = args.folder
+    if not repo_path.is_dir():
+        print(f"Error: {repo_path} is not a valid directory.", file=sys.stderr)  # noqa: T201 # this just runs as a simple script, so using print instead of log
+        sys.exit(1)
+
+    # Retrieve the list of Git-tracked files.
+    files = get_tracked_files(repo_path)
+
+    # If the debug flag is specified, print out all discovered files.
+    if args.debug:
+        print("Tracked files discovered:")  # noqa: T201 # this just runs as a simple script, so using print instead of log
+        for file in files:
+            print(file)  # noqa: T201 # this just runs as a simple script, so using print instead of log
+
+    # Compute and print the overall Adler-32 checksum.
+    overall_checksum = compute_adler32(repo_path, files)
+    # Format the checksum as an 8-digit hexadecimal value.
+    print(f"{overall_checksum:08x}")  # noqa: T201 # need to print this so that the value can be picked up via STDOUT when calling this in a CI pipeline or as a subprocess
+
+
+if __name__ == "__main__":
+    main()

--- a/template/.devcontainer/create-aws-profile.sh.jinja-base
+++ b/template/.devcontainer/create-aws-profile.sh.jinja-base
@@ -26,7 +26,7 @@ region={% endraw %}{{ aws_org_home_region if (aws_org_home_region is defined and
 output=json
 endpoint_url = $LOCALSTACK_ENDPOINT_URL
 
-{% endraw %}{% if aws_central_infrastructure_account_id is defined and aws_central_infrastructure_account_id != "" %}{% raw %}
+{% endraw %}{% if aws_central_infrastructure_account_id is defined and aws_central_infrastructure_account_id != "" and aws_central_infrastructure_account_id != "000000000000" %}{% raw %}
 [profile {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}]
 sso_session = org
 sso_role_name = {% endraw %}{{ core_infra_base_access_profile_name }}{% raw %}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -84,7 +84,7 @@ jobs:
           echo "build_context_tag=context-${BUILD_HASH}" >> "$GITHUB_OUTPUT"
           echo "Calculated build context tag as: ${BUILD_HASH}"
 
-          IMAGE_NAME_WITH_NAMESPACE=${{ inputs.image_name }}"
+          IMAGE_NAME_WITH_NAMESPACE="${{ inputs.image_name }}"
           IMAGE_NAME_NO_SLASHES="${IMAGE_NAME_WITH_NAMESPACE//\//-}"
           echo "image_name_no_slashes=${IMAGE_NAME_NO_SLASHES}" >> "$GITHUB_OUTPUT"
           echo "Image name without slashes: ${IMAGE_NAME_NO_SLASHES}"

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -83,6 +83,11 @@ jobs:
           BUILD_HASH=$(python3 .github/workflows/hash_git_files.py ${{ inputs.context }})
           echo "build_context_tag=context-${BUILD_HASH}" >> "$GITHUB_OUTPUT"
 
+          IMAGE_NAME_WITH_NAMESPACE=${{ inputs.image_name }}"
+          IMAGE_NAME_NO_SLASHES="${IMAGE_NAME_WITH_NAMESPACE//\//-}"
+          echo "image_name_no_slashes=${IMAGE_NAME_NO_SLASHES}" >> "$GITHUB_OUTPUT"
+          echo "Image name without slashes: ${IMAGE_NAME_NO_SLASHES}"
+
       - name: Test if docker image exists
         if: ${{ inputs.push-role-name != 'no-push' }}
         id: check-if-exists
@@ -117,16 +122,16 @@ jobs:
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
           tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
-
+      # - name: Add git sha tag
 
       - name: Save Docker Image as tar
         if: ${{ inputs.save-as-artifact }}
-        run: docker save -o ${{ inputs.image_name }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
+        run: docker save -o ${{ inputs.steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
       - name: Upload Docker Image Artifact
         if: ${{ inputs.save-as-artifact }}
         uses: actions/upload-artifact@{% endraw %}{{ gha_upload_artifact }}{% raw %}
         with:
-          name: ${{ inputs.image_name }}
-          path: ${{ inputs.image_name }}.tar
+          name: ${{ inputs.steps.calculate-build-context-hash.outputs.image_name_no_slashes }}
+          path: ${{ inputs.steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar
           if-no-files-found: error{% endraw %}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -81,15 +81,15 @@ jobs:
         run: |
           python3 --version
           BUILD_HASH=$(python3 .github/workflows/hash_git_files.py ${{ inputs.context }})
-          echo "build_context_hash=${BUILD_HASH}" >> "$GITHUB_OUTPUT"
+          echo "build_context_tag=context-${BUILD_HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Test if docker image exists
         if: ${{ inputs.push-role-name != 'no-push' }}
         id: check-if-exists
         run: |
-          BUILD_HASH=${{ steps.calculate-build-context-hash.outputs.build_context_hash }}
+          BUILD_HASH=${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
           echo Checking for : $BUILD_HASH
-          if aws ecr describe-images --region ${{ steps.parse_ecr_url.outputs.aws_region }} --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ needs.generate-hash.outputs.repo-name }} --registry-id=${{ needs.generate-hash.outputs.ecr-registry-id }} --image-ids=imageTag=$BUILD_HASH; then \
+          if aws ecr describe-images --region ${{ steps.parse_ecr_url.outputs.aws_region }} --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$BUILD_HASH; then \
             echo "Image was found in ECR"; \
             echo "status=found" >> $GITHUB_OUTPUT
           else \
@@ -115,11 +115,13 @@ jobs:
           context: ${{ inputs.context }}
           push: ${{ inputs.push-role-name != 'no-push' }}
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
-          tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_hash }}
+          tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
+
+      - name: Add git sha tag
 
       - name: Save Docker Image as tar
         if: ${{ inputs.save-as-artifact }}
-        run: docker save -o ${{ inputs.image_name }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_hash }}
+        run: docker save -o ${{ inputs.image_name }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
       - name: Upload Docker Image Artifact
         if: ${{ inputs.save-as-artifact }}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -82,6 +82,7 @@ jobs:
           python3 --version
           BUILD_HASH=$(python3 .github/workflows/hash_git_files.py ${{ inputs.context }})
           echo "build_context_tag=context-${BUILD_HASH}" >> "$GITHUB_OUTPUT"
+          echo "Calculated build context tag as: ${BUILD_HASH}"
 
           IMAGE_NAME_WITH_NAMESPACE=${{ inputs.image_name }}"
           IMAGE_NAME_NO_SLASHES="${IMAGE_NAME_WITH_NAMESPACE//\//-}"

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -127,7 +127,19 @@ jobs:
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
           tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
-      # - name: Add git sha tag
+      - name: Add git sha tag
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        run: |
+          aws ecr batch-get-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids imageTag=${{ steps.calculate-build-context-hash.outputs.build_context_tag }} --query 'images[].imageManifest' --output text > manifest.json
+          aws ecr put-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-tag git-sha-${{ github.sha }} --image-manifest file://manifest.json
+
+      - name: Add tag for Production
+        if: ${{ inputs.push-role-name != 'no-push' && inputs.tag-for-production }}
+        run: |
+          aws ecr batch-get-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids imageTag=${{ steps.calculate-build-context-hash.outputs.build_context_tag }} --query 'images[].imageManifest' --output text > manifest.json
+          # TODO: figure out some better conditional logic about adding a tag for the context in production, so we don't have to `|| true` at the end
+          aws ecr put-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-tag production--${{ steps.calculate-build-context-hash.outputs.build_context_tag }} --image-manifest file://manifest.json || true
+          aws ecr put-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-tag production--git-sha-${{ github.sha }} --image-manifest file://manifest.json
 
       - name: Save Docker Image as tar
         if: ${{ inputs.save-as-artifact }}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -20,15 +20,65 @@ on:
         type: string
         required: false
         default: './'
+      push-role-name:
+        type: string
+        description: What's the IAM role name to use for Pushing to the ECR?
+        required: false
+        default: no-push
+      save-as-artifact:
+        type: boolean
+        description: 'Should the image be saved as an artifact?'
+        required: false
+        default: false
 
+permissions:
+    id-token: write
+    contents: write # needed for mutex
 
 jobs:
   build-image:
     name: Build Docker Image
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
     steps:
+      - name: Parse ECR URL
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        id: parse_ecr_url
+        run: |
+          ECR_URL="${{ inputs.repository}}"
+
+          # Extract the AWS Account ID, which is the first field
+          AWS_ACCOUNT_ID=$(echo "$ECR_URL" | cut -d. -f1)
+
+          # Extract the AWS Region, which is the fourth field in the URL structure
+          AWS_REGION=$(echo "$ECR_URL" | cut -d. -f4)
+
+          # Set the outputs for use in later steps
+          echo "aws_account_id=${AWS_ACCOUNT_ID}" >> "$GITHUB_OUTPUT"
+          echo "aws_region=${AWS_REGION}" >> "$GITHUB_OUTPUT"
+        shell: bash
+
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+
+      - name: OIDC Auth for ECR
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
+        with:
+          role-to-assume: arn:aws:iam::${{ steps.parse_ecr_url.outputs.aws_account_id }}:role/${{ inputs.push-role-name }}
+          aws-region: ${{ steps.parse_ecr_url.outputs.aws_region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@{% endraw %}{{ gha_amazon_ecr_login }}{% raw %}
+
+      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
+        with:
+          branch: mutex-${{ inputs.repository }}-${{ inputs.image_name }}
+        timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
+
+      # TODO: check if tag already exists
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@{% endraw %}{{ gha_setup_buildx }}{% raw %}
@@ -39,14 +89,16 @@ jobs:
         uses: docker/build-push-action@{% endraw %}{{ gha_docker_build_push }}{% raw %}
         with:
           context: ${{ inputs.context }}
-          push: false
-          load: true # make the image available later for the `docker save` step
+          push: ${{ inputs.push-role-name != 'no-push' }}
+          load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
           tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ inputs.tag }}
 
       - name: Save Docker Image as tar
+        if: ${{ inputs.save-as-artifact }}
         run: docker save -o ${{ inputs.image_name }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ inputs.tag }}
 
       - name: Upload Docker Image Artifact
+        if: ${{ inputs.save-as-artifact }}
         uses: actions/upload-artifact@{% endraw %}{{ gha_upload_artifact }}{% raw %}
         with:
           name: ${{ inputs.image_name }}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -11,10 +11,11 @@ on:
         description: 'Docker image name'
         type: string
         required: true
-      tag:
-        description: 'Docker image tag'
-        type: string
-        required: true
+      tag-for-production:
+        description: 'Whether or not to add a tag indicating this is being used in production'
+        type: boolean
+        required: false
+        default: false
       context:
         description: 'Build context path'
         type: string
@@ -67,10 +68,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ steps.parse_ecr_url.outputs.aws_account_id }}:role/${{ inputs.push-role-name }}
           aws-region: ${{ steps.parse_ecr_url.outputs.aws_region }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@{% endraw %}{{ gha_amazon_ecr_login }}{% raw %}
-
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
         if: ${{ inputs.push-role-name != 'no-push' }}
         uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
@@ -79,23 +76,50 @@ jobs:
         timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       # TODO: check if tag already exists
+      - name: Calculate hash of files in build context
+        id: calculate-build-context-hash
+        run: |
+          python3 --version
+          BUILD_HASH=$(python3 .github/workflows/hash_git_files.py ${{ inputs.context }})
+          echo "build_context_hash=${BUILD_HASH}" >> "$GITHUB_OUTPUT"
+
+      - name: Test if docker image exists
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        id: check-if-exists
+        run: |
+          BUILD_HASH=${{ steps.calculate-build-context-hash.outputs.build_context_hash }}
+          echo Checking for : $BUILD_HASH
+          if aws ecr describe-images --region ${{ steps.parse_ecr_url.outputs.aws_region }} --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ needs.generate-hash.outputs.repo-name }} --registry-id=${{ needs.generate-hash.outputs.ecr-registry-id }} --image-ids=imageTag=$BUILD_HASH; then \
+            echo "Image was found in ECR"; \
+            echo "status=found" >> $GITHUB_OUTPUT
+          else \
+            echo "Image was not found in ECR"; \
+            echo "status=notfound" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to Amazon ECR
+        if: ${{ inputs.push-role-name != 'no-push' && steps.check-if-exists.outputs.status == 'notfound' }}
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@{% endraw %}{{ gha_amazon_ecr_login }}{% raw %}
 
       - name: Set up Docker Buildx
+        if: ${{ inputs.save-as-artifact || steps.check-if-exists.outputs.status == 'notfound' }}
         uses: docker/setup-buildx-action@{% endraw %}{{ gha_setup_buildx }}{% raw %}
         with:
           version: {% endraw %}{{ buildx_version }}{% raw %}
 
       - name: Build Docker Image
+        if: ${{ inputs.save-as-artifact || steps.check-if-exists.outputs.status == 'notfound' }}
         uses: docker/build-push-action@{% endraw %}{{ gha_docker_build_push }}{% raw %}
         with:
           context: ${{ inputs.context }}
           push: ${{ inputs.push-role-name != 'no-push' }}
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
-          tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ inputs.tag }}
+          tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_hash }}
 
       - name: Save Docker Image as tar
         if: ${{ inputs.save-as-artifact }}
-        run: docker save -o ${{ inputs.image_name }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ inputs.tag }}
+        run: docker save -o ${{ inputs.image_name }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_hash }}
 
       - name: Upload Docker Image Artifact
         if: ${{ inputs.save-as-artifact }}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -117,7 +117,7 @@ jobs:
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
           tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
-      - name: Add git sha tag
+
 
       - name: Save Docker Image as tar
         if: ${{ inputs.save-as-artifact }}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -126,12 +126,12 @@ jobs:
 
       - name: Save Docker Image as tar
         if: ${{ inputs.save-as-artifact }}
-        run: docker save -o ${{ inputs.steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
+        run: docker save -o ${{ steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
       - name: Upload Docker Image Artifact
         if: ${{ inputs.save-as-artifact }}
         uses: actions/upload-artifact@{% endraw %}{{ gha_upload_artifact }}{% raw %}
         with:
-          name: ${{ inputs.steps.calculate-build-context-hash.outputs.image_name_no_slashes }}
-          path: ${{ inputs.steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar
+          name: ${{ steps.calculate-build-context-hash.outputs.image_name_no_slashes }}
+          path: ${{ steps.calculate-build-context-hash.outputs.image_name_no_slashes }}.tar
           if-no-files-found: error{% endraw %}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -68,14 +68,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ steps.parse_ecr_url.outputs.aws_account_id }}:role/${{ inputs.push-role-name }}
           aws-region: ${{ steps.parse_ecr_url.outputs.aws_region }}
 
-      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
-        if: ${{ inputs.push-role-name != 'no-push' }}
-        uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
-        with:
-          branch: mutex-${{ inputs.repository }}-${{ inputs.image_name }}
-        timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
-
-      # TODO: check if tag already exists
       - name: Calculate hash of files in build context
         id: calculate-build-context-hash
         run: |
@@ -88,6 +80,13 @@ jobs:
           IMAGE_NAME_NO_SLASHES="${IMAGE_NAME_WITH_NAMESPACE//\//-}"
           echo "image_name_no_slashes=${IMAGE_NAME_NO_SLASHES}" >> "$GITHUB_OUTPUT"
           echo "Image name without slashes: ${IMAGE_NAME_NO_SLASHES}"
+
+      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
+        with:
+          branch: mutex-${{ inputs.repository }}-${{ inputs.image_name }}
+        timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       - name: Test if docker image exists
         if: ${{ inputs.push-role-name != 'no-push' }}
@@ -119,7 +118,7 @@ jobs:
         uses: docker/build-push-action@{% endraw %}{{ gha_docker_build_push }}{% raw %}
         with:
           context: ${{ inputs.context }}
-          push: ${{ inputs.push-role-name != 'no-push' }}
+          push: ${{ inputs.push-role-name != 'no-push' && steps.check-if-exists.outputs.status == 'notfound' }}
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
           tags: ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -108,7 +108,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@{% endraw %}{{ gha_amazon_ecr_login }}{% raw %}
 
       - name: Pull existing image to package as artifact
-        if: ${{ inputs.save-as-artifact && steps.check-if-exists.outputs.status != 'notfound' }}
+        if: ${{ inputs.save-as-artifact && steps.check-if-exists.outputs.status == 'found' }}
         run: |
           docker pull ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -113,13 +113,13 @@ jobs:
           docker pull ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
       - name: Set up Docker Buildx
-        if: ${{ inputs.save-as-artifact || steps.check-if-exists.outputs.status == 'notfound' }}
+        if: ${{ (inputs.save-as-artifact && inputs.push-role-name == 'no-push') || steps.check-if-exists.outputs.status == 'notfound' }}
         uses: docker/setup-buildx-action@{% endraw %}{{ gha_setup_buildx }}{% raw %}
         with:
           version: {% endraw %}{{ buildx_version }}{% raw %}
 
       - name: Build Docker Image
-        if: ${{ inputs.save-as-artifact || steps.check-if-exists.outputs.status == 'notfound' }}
+        if: ${{ (inputs.save-as-artifact && inputs.push-role-name == 'no-push') || steps.check-if-exists.outputs.status == 'notfound' }}
         uses: docker/build-push-action@{% endraw %}{{ gha_docker_build_push }}{% raw %}
         with:
           context: ${{ inputs.context }}

--- a/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
+++ b/template/.github/reusable_workflows/build-docker-image.yaml.jinja-base
@@ -103,9 +103,14 @@ jobs:
           fi
 
       - name: Login to Amazon ECR
-        if: ${{ inputs.push-role-name != 'no-push' && steps.check-if-exists.outputs.status == 'notfound' }}
+        if: ${{ inputs.push-role-name != 'no-push' && (steps.check-if-exists.outputs.status == 'notfound' || inputs.save-as-artifact ) }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@{% endraw %}{{ gha_amazon_ecr_login }}{% raw %}
+
+      - name: Pull existing image to package as artifact
+        if: ${{ inputs.save-as-artifact && steps.check-if-exists.outputs.status != 'notfound' }}
+        run: |
+          docker pull ${{ inputs.repository }}/${{ inputs.image_name }}:${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
 
       - name: Set up Docker Buildx
         if: ${{ inputs.save-as-artifact || steps.check-if-exists.outputs.status == 'notfound' }}

--- a/template/.github/reusable_workflows/hash_git_files.py
+++ b/template/.github/reusable_workflows/hash_git_files.py
@@ -1,0 +1,1 @@
+../../../src/hash_git_files.py

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -32,11 +32,6 @@ node_version:
     help: What version of NodeJS is used for development?
     default: 22.14.0
 
-pnpm_version:
-    type: str
-    help: What version of pnpm is used for development?
-    default: 10.6.3
-
 {% endraw %}{% endif %}{% raw %}{% endraw %}{% if template_might_want_to_install_aws_ssm_port_forwarding_plugin %}{% raw %}
 install_aws_ssm_port_forwarding_plugin:
     type: bool

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -75,6 +75,7 @@ aws_central_infrastructure_account_id:
     type: str
     help: What's the ID of your Organization's AWS Account containing Central Infrastructure (e.g. CodeArtifact)?
     when: "{{ python_package_registry == 'AWS CodeArtifact' }}"
+    default: "000000000000"
 
 core_infra_base_access_profile_name:
     type: str

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -48,6 +48,7 @@ class ContextUpdater(ContextHook):
         context["buildx_version"] = "{{ buildx_version }}"
         context["gha_docker_build_push"] = "{{ gha_docker_build_push }}"
         context["gha_configure_aws_credentials"] = "{{ gha_configure_aws_credentials }}"
+        context["gha_amazon_ecr_login"] = "{{ gha_amazon_ecr_login }}"
         context["gha_setup_node"] = "{{ gha_setup_node }}"
         context["gha_action_gh_release"] = "{{ gha_action_gh_release }}"
         context["gha_mutex"] = "{{ gha_mutex }}"

--- a/template/tests/copier_data/data1.yaml.jinja-base
+++ b/template/tests/copier_data/data1.yaml.jinja-base
@@ -7,8 +7,7 @@ ssh_port_number: 12345
 use_windows_in_ci: false
 {% endraw %}{% if template_might_want_to_install_aws_ssm_port_forwarding_plugin %}{% raw %}install_aws_ssm_port_forwarding_plugin: true{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_javascript %}{% raw %}
-node_version: 22.13.0
-pnpm_version: 9.15.4{% endraw %}{% endif %}{% raw %}
+node_version: 22.13.0{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_python %}{% raw %}
 python_package_registry: PyPI
 aws_identity_center_id: d-9145c20053

--- a/template/tests/copier_data/data2.yaml.jinja-base
+++ b/template/tests/copier_data/data2.yaml.jinja-base
@@ -7,8 +7,7 @@ ssh_port_number: 54321
 use_windows_in_ci: true
 {% endraw %}{% if template_might_want_to_install_aws_ssm_port_forwarding_plugin %}{% raw %}install_aws_ssm_port_forwarding_plugin: false{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_javascript %}{% raw %}
-node_version: 22.14.0
-pnpm_version: 10.6.3{% endraw %}{% endif %}{% raw %}
+node_version: 22.14.0{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if template_uses_python %}{% raw %}
 python_package_registry: AWS CodeArtifact
 aws_central_infrastructure_account_id: 012321432543

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = ">=9.6.0" },
     { name = "copier-templates-extensions", specifier = ">=0.3.0" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.398" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.399" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
@@ -358,15 +358,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.398"
+version = "1.1.399"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/d6/48740f1d029e9fc4194880d1ad03dcf0ba3a8f802e0e166b8f63350b3584/pyright-1.1.398.tar.gz", hash = "sha256:357a13edd9be8082dc73be51190913e475fa41a6efb6ec0d4b7aab3bc11638d8", size = 3892675 }
+sdist = { url = "https://files.pythonhosted.org/packages/db/9d/d91d5f6d26b2db95476fefc772e2b9a16d54c6bd0ea6bb5c1b6d635ab8b4/pyright-1.1.399.tar.gz", hash = "sha256:439035d707a36c3d1b443aec980bc37053fbda88158eded24b8eedcf1c7b7a1b", size = 3856954 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/e0/5283593f61b3c525d6d7e94cfb6b3ded20b3df66e953acaf7bb4f23b3f6e/pyright-1.1.398-py3-none-any.whl", hash = "sha256:0a70bfd007d9ea7de1cf9740e1ad1a40a122592cfe22a3f6791b06162ad08753", size = 5780235 },
+    { url = "https://files.pythonhosted.org/packages/2f/b5/380380c9e7a534cb1783c70c3e8ac6d1193c599650a55838d0557586796e/pyright-1.1.399-py3-none-any.whl", hash = "sha256:55f9a875ddf23c9698f24208c764465ffdfd38be6265f7faf9a176e1dc549f3b", size = 5592584 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why is this change necessary?
Need to be able to push to ECR


 ## How does this change address the issue?
Updates so the build workflow can push to ECR and tag images accordingly (build context hash, git sha)


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repos


 ## Other
bumped some dependencies
removed pnpm_version as a template question