### PR TITLE
Add inline disable for typos

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): fc88ae3c
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): a1ea6406 # spellchecker:disable-line
 }

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,9 @@
+[default]
+extend-ignore-re = [
+# Line ignore with trailing: # spellchecker:disable-line
+"(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"
+]
+
 [default.extend-words]
 # Words managed by the base template
 # `astroid` is the name of a python library, and it is used in pylint configuration. should not be corrected to asteroid

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -60,6 +60,8 @@ class ContextUpdater(ContextHook):
         context["gha_setup_node"] = "v4.3.0"
         context["gha_action_gh_release"] = "v2.2.1"
         context["gha_mutex"] = "1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10"
+        context["gha_pypi_publish"] = "v1.12.4"
+        context["gha_sleep"] = "v2.0.3"
         context["gha_windows_runner"] = "windows-2025"
         #######
         context["debian_release_name"] = "bookworm"

--- a/src/hash_git_files.py
+++ b/src/hash_git_files.py
@@ -10,6 +10,10 @@ DEVCONTAINER_COMMENT_LINE_PREFIX = (
     "  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): "
 )
 
+DEVCONTAINER_COMMENT_LINE_SUFFIX = (
+    " # spellchecker:disable-line"  # the typos hook can sometimes mess with the hash without this
+)
+
 
 def get_tracked_files(repo_path: Path) -> list[str]:
     """Return a list of files tracked by Git in the given repository folder, using the 'git ls-files' command."""
@@ -76,9 +80,13 @@ def find_devcontainer_hash_line(lines: list[str]) -> tuple[int, str | None]:
     for i in range(len(lines) - 1, -1, -1):
         if lines[i].strip() == "}":
             # Check the line above it
-            if i > 0 and lines[i - 1].startswith(DEVCONTAINER_COMMENT_LINE_PREFIX):
-                current_hash = lines[i - 1].split(": ", 1)[1].strip()
-                return i - 1, current_hash
+            if i > 0:
+                above_line = lines[i - 1]
+                if above_line.startswith(DEVCONTAINER_COMMENT_LINE_PREFIX):
+                    part_after_prefix = above_line.split(": ", 1)[1]
+                    part_before_suffix = part_after_prefix.split("#")[0]
+                    current_hash = part_before_suffix.strip()
+                    return i - 1, current_hash
             return i, None
     return -1, None
 
@@ -102,12 +110,13 @@ def update_devcontainer_context_hash(devcontainer_json_file: Path, new_hash: str
             lines = file.readlines()
 
         line_index, current_hash = find_devcontainer_hash_line(lines)
+        new_hash_line = f"{DEVCONTAINER_COMMENT_LINE_PREFIX}{new_hash}{DEVCONTAINER_COMMENT_LINE_SUFFIX}\n"
         if current_hash is not None:
             # Replace the old hash with the new hash
-            lines[line_index] = f"{DEVCONTAINER_COMMENT_LINE_PREFIX}{new_hash}\n"
+            lines[line_index] = new_hash_line
         else:
             # Insert the new hash line above the closing `}`
-            lines.insert(line_index, f"{DEVCONTAINER_COMMENT_LINE_PREFIX}{new_hash}\n")
+            lines.insert(line_index, new_hash_line)
 
         # Write the updated lines back to the file
         with devcontainer_json_file.open("w", encoding="utf-8") as file:

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -52,6 +52,8 @@ class ContextUpdater(ContextHook):
         context["gha_setup_node"] = "{{ gha_setup_node }}"
         context["gha_action_gh_release"] = "{{ gha_action_gh_release }}"
         context["gha_mutex"] = "{{ gha_mutex }}"
+        context["gha_pypi_publish"] = {{ gha_pypi_publish }}"
+        context["gha_sleep"] = "{{ gha_sleep }}"
         context["gha_linux_runner"] = "{{ gha_linux_runner }}"
         context["gha_windows_runner"] = "{{ gha_windows_runner }}"
 

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -52,7 +52,7 @@ class ContextUpdater(ContextHook):
         context["gha_setup_node"] = "{{ gha_setup_node }}"
         context["gha_action_gh_release"] = "{{ gha_action_gh_release }}"
         context["gha_mutex"] = "{{ gha_mutex }}"
-        context["gha_pypi_publish"] = {{ gha_pypi_publish }}"
+        context["gha_pypi_publish"] = "{{ gha_pypi_publish }}"
         context["gha_sleep"] = "{{ gha_sleep }}"
         context["gha_linux_runner"] = "{{ gha_linux_runner }}"
         context["gha_windows_runner"] = "{{ gha_windows_runner }}"


### PR DESCRIPTION
 ## Why is this change necessary?
Wasn't able to inline disable the typos checker.  and it was causing problems with the devcontainer hash


 ## How does this change address the issue?
Adds regex config. and auto disables spellcheck on the hash line


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo


 ## Other
Added some context vars