### PR TITLE
Fix: SSH port randomization

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 180a89f4 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4a4a8b75 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): a1ea6406 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 180a89f4 # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.sh
+++ b/.devcontainer/install-ci-tooling.sh
@@ -6,13 +6,14 @@ curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 
-# Ensure that uv won't use the default system Python
-default_version="3.12.7"
+# Set to the system version of Python3 by default
+default_version=$(python3 -c "import sys; print ('.'.join((str(x) for x in sys.version_info[:3])))")
 
 # Use the input argument if provided, otherwise use the default value
 input="${1:-$default_version}"
 
 export UV_PYTHON="$input"
+echo "Using Python version: $UV_PYTHON"
 export UV_PYTHON_PREFERENCE=only-system
 
 uv tool install 'copier==9.6.0' --with 'copier-templates-extensions==0.3.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
   - repo: https://github.com/crate-ci/typos
-    rev: 15ff058881549e16b0edb975a9b0b0d0cccd612c  # frozen: v1
+    rev: 6cb49915af2e93e61f5f0d0a82216e28ad5c7c18  # frozen: v1
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -189,7 +189,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: e84319e627902e1b348574ecf3238dc511933dc7  # frozen: v0.11.7
+    rev: f0fe93c067104b76ffb58852abe79673a8429bd1  # frozen: v0.11.8
     hooks:
       - id: ruff
         name: ruff-src
@@ -202,7 +202,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: 7ac5a4d4f77576df3a00e63f86ca86e0e1780b47  # frozen: v3.3.6
+    rev: f798a4a3508bcbb8ad0773ae14bf32d28dcfdcbe  # frozen: v3.3.7
     hooks:
       - id: pylint
         name: pylint

--- a/copier.yaml
+++ b/copier.yaml
@@ -28,7 +28,7 @@ ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
     # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-    default: "{{ ([p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468))] | random }}"
+    default: "{{ [p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468)] | random }}"
 
 template_uses_python:
     type: bool

--- a/copier.yaml
+++ b/copier.yaml
@@ -27,8 +27,8 @@ python_ci_versions:
 ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
-    default: "{{ random_ssh_port }}"
-
+    # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
+    default: "{{ ( (range(49152, 49752)   | list) + (range(49852, 50000)   | list) + (range(50060, 50160)   | list) + (range(50160, 50260)   | list) + (range(50260, 50360)   | list) + (range(50914, 51014)   | list) + (range(51114, 51214)   | list) + (range(51214, 51314)   | list) + (range(51314, 51414)   | list) + (range(51623, 51723)   | list) + (range(51723, 51823)   | list) + (range(65269, 65369)   | list) + (range(65369, 65469)   | list) ) | random }}"
 template_uses_python:
     type: bool
     help: Is this a template that will use Python within it?

--- a/copier.yaml
+++ b/copier.yaml
@@ -27,8 +27,7 @@ python_ci_versions:
 ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
-    # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-    default: "{{ [p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468)] | random }}"
+    default: "{{ random_ssh_port }}"
 
 template_uses_python:
     type: bool

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -1,5 +1,4 @@
 # adapted from https://github.com/copier-org/copier-templates-extensions#context-hook-extension
-import random
 from typing import Any
 from typing import override
 
@@ -75,31 +74,4 @@ class ContextUpdater(ContextHook):
         context["aws_region_for_stack"] = "us-east-1"
         # Kludge to be able to stop symlinked jinja files from being updated in child templates when the variable is really meant for the instantiated grandchild template
         context["is_child_of_copier_base_template"] = True
-        # this `random_ssh_port` code is copied into the template's context.py.jinja
-        context["random_ssh_port"] = (
-            random.choice(  # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-                [
-                    p
-                    for p in range(49152, 65536)
-                    if not any(
-                        start <= p <= end
-                        for start, end in [
-                            (49752, 49851),
-                            (50000, 50059),
-                            (50060, 50159),
-                            (50160, 50259),
-                            (50260, 50359),
-                            (50914, 51013),
-                            (51114, 51213),
-                            (51214, 51313),
-                            (51314, 51413),
-                            (51623, 51722),
-                            (51723, 51822),
-                            (65269, 65368),
-                            (65369, 65468),
-                        ]
-                    )
-                ]
-            )
-        )
         return context

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -30,7 +30,7 @@ class ContextUpdater(ContextHook):
         context["pulumi_aws_version"] = "6.77.0"
         context["pulumi_aws_native_version"] = "1.27.0"
         context["pulumi_command_version"] = "1.0.2"
-        context["pulumi_github"] = "6.7.0"
+        context["pulumi_github"] = "6.7.2"
         context["boto3_version"] = "1.37.11"
         context["ephemeral_pulumi_deploy_version"] = "0.0.4"
         context["pydantic_version"] = "2.11.1"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -26,7 +26,7 @@ class ContextUpdater(ContextHook):
         context["pytest_cov_version"] = "6.0.0"
         #######
         context["sphinx_version"] = "8.1.3"
-        context["pulumi_version"] = "3.163.0"
+        context["pulumi_version"] = "3.167.0"
         context["pulumi_aws_version"] = "6.77.0"
         context["pulumi_aws_native_version"] = "1.27.0"
         context["pulumi_command_version"] = "1.0.2"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -1,4 +1,5 @@
 # adapted from https://github.com/copier-org/copier-templates-extensions#context-hook-extension
+import random
 from typing import Any
 from typing import override
 
@@ -74,4 +75,31 @@ class ContextUpdater(ContextHook):
         context["aws_region_for_stack"] = "us-east-1"
         # Kludge to be able to stop symlinked jinja files from being updated in child templates when the variable is really meant for the instantiated grandchild template
         context["is_child_of_copier_base_template"] = True
+        # this `random_ssh_port` code is copied into the template's context.py.jinja
+        context["random_ssh_port"] = (
+            random.choice(  # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
+                [
+                    p
+                    for p in range(49152, 65536)
+                    if not any(
+                        start <= p <= end
+                        for start, end in [
+                            (49752, 49851),
+                            (50000, 50059),
+                            (50060, 50159),
+                            (50160, 50259),
+                            (50260, 50359),
+                            (50914, 51013),
+                            (51114, 51213),
+                            (51214, 51313),
+                            (51314, 51413),
+                            (51623, 51722),
+                            (51723, 51822),
+                            (65269, 65368),
+                            (65369, 65468),
+                        ]
+                    )
+                ]
+            )
+        )
         return context

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -38,7 +38,7 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = "0.264.0"
         context["fastapi_version"] = "0.115.12"
         context["uvicorn_version"] = "0.34.0"
-        context["lab_auto_pulumi_version"] = "0.1.11"
+        context["lab_auto_pulumi_version"] = "0.1.12"
         #######
         context["nuxt_ui_version"] = "^3.0.2"
         context["nuxt_version"] = "^3.16.2"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -40,8 +40,8 @@ class ContextUpdater(ContextHook):
         context["uvicorn_version"] = "0.34.0"
         context["lab_auto_pulumi_version"] = "0.1.12"
         #######
-        context["nuxt_ui_version"] = "^3.0.2"
-        context["nuxt_version"] = "^3.16.2"
+        context["nuxt_ui_version"] = "^3.1.1"
+        context["nuxt_version"] = "^3.17.2"
         context["typescript_version"] = "^5.8.2"
         #######
         # These are duplicated in the CI files for this repository

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -61,7 +61,7 @@
         "ruff.nativeServer": "on",
         // TODO: see if there's a way to specify different configurations for different folders
         "ruff.configuration": "/workspaces/{% endraw %}{{ repo_name }}{% raw %}/ruff-test.toml", // use the test configuration since it's less restrictive and won't show false positives and underline things
-        "[jsonc][json][javascript][typescript][graphql]": {
+        "[jsonc][json][javascript][typescript][graphql][css][scss][html][vue]": {
           "editor.defaultFormatter": "esbenp.prettier-vscode",
           "editor.formatOnSave": true
         }

--- a/template/README.md.jinja-base
+++ b/template/README.md.jinja-base
@@ -7,7 +7,7 @@
 # Usage
 To create a new repository using this template:
 1. Install `copier` and `copier-templates-extensions`. An easy way to do that is to copy the `.devcontainer/install-ci-tooling.sh` script in this repository into your new repo and then run it.
-2. Run copier to instantiate the template: `copier copy --trust gh:{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}.git`
+2. Run copier to instantiate the template: `copier copy --trust gh:{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}.git .`
 3. Run `uv lock` to generate the lock file
 4. Commit the changes
 5. Rebuild your new devcontainer

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -19,7 +19,7 @@ is_open_source:
 ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
-    default: "{{ random_ssh_port }}"
+    default: "{{ ( (range(49152, 49752)   | list) + (range(49852, 50000)   | list) + (range(50060, 50160)   | list) + (range(50160, 50260)   | list) + (range(50260, 50360)   | list) + (range(50914, 51014)   | list) + (range(51114, 51214)   | list) + (range(51214, 51314)   | list) + (range(51314, 51414)   | list) + (range(51623, 51723)   | list) + (range(51723, 51823)   | list) + (range(65269, 65369)   | list) + (range(65369, 65469)   | list) ) | random }}"
 
 use_windows_in_ci:
     type: bool

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -20,7 +20,7 @@ ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
     # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-    default: "{{ [p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468)] | random }}"
+    default: "{{ ([p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468)]) | random }}"
 
 use_windows_in_ci:
     type: bool

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -19,8 +19,7 @@ is_open_source:
 ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
-    # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-    default: "{{ ([p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468)]) | random }}"
+    default: "{{ random_ssh_port }}"
 
 use_windows_in_ci:
     type: bool

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -20,7 +20,7 @@ ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
     # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-    default: "{{ ([p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468))] | random }}"
+    default: "{{ [p for p in range(49152, 65536) if not (49752 <= p <= 49851 or 50000 <= p <= 50059 or 50060 <= p <= 50159 or 50160 <= p <= 50259 or 50260 <= p <= 50359 or 50914 <= p <= 51013 or 51114 <= p <= 51213 or 51214 <= p <= 51313 or 51314 <= p <= 51413 or 51623 <= p <= 51722 or 51723 <= p <= 51822 or 65269 <= p <= 65368 or 65369 <= p <= 65468)] | random }}"
 
 use_windows_in_ci:
     type: bool

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -19,6 +19,7 @@ is_open_source:
 ssh_port_number:
     type: int
     help: What port should the devcontainer bind SSH to?
+    # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
     default: "{{ ( (range(49152, 49752)   | list) + (range(49852, 50000)   | list) + (range(50060, 50160)   | list) + (range(50160, 50260)   | list) + (range(50260, 50360)   | list) + (range(50914, 51014)   | list) + (range(51114, 51214)   | list) + (range(51214, 51314)   | list) + (range(51314, 51414)   | list) + (range(51623, 51723)   | list) + (range(51723, 51823)   | list) + (range(65269, 65369)   | list) + (range(65369, 65469)   | list) ) | random }}"
 
 use_windows_in_ci:

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -67,4 +67,30 @@ class ContextUpdater(ContextHook):
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = {{ "True" if template_uses_vuejs else "False" }}
         context["template_uses_javascript"] = {{ "True" if template_uses_javascript else "False" }}
+        context["random_ssh_port"] = (
+            random.choice(  # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
+                [
+                    p
+                    for p in range(49152, 65536)
+                    if not any(
+                        start <= p <= end
+                        for start, end in [
+                            (49752, 49851),
+                            (50000, 50059),
+                            (50060, 50159),
+                            (50160, 50259),
+                            (50260, 50359),
+                            (50914, 51013),
+                            (51114, 51213),
+                            (51214, 51313),
+                            (51314, 51413),
+                            (51623, 51722),
+                            (51723, 51822),
+                            (65269, 65368),
+                            (65369, 65468),
+                        ]
+                    )
+                ]
+            )
+        )
         return context

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -1,5 +1,4 @@
 {% raw %}# adapted from https://github.com/copier-org/copier-templates-extensions#context-hook-extension
-import random
 from typing import Any
 from typing import override
 
@@ -68,30 +67,4 @@ class ContextUpdater(ContextHook):
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = {{ "True" if template_uses_vuejs else "False" }}
         context["template_uses_javascript"] = {{ "True" if template_uses_javascript else "False" }}
-        context["random_ssh_port"] = (
-            random.choice(  # Pick a random port, but ensure it's not in the excluded port range on Windows (powershell: `netsh int ipv4 show excludedportrange protocol=tcp`)
-                [
-                    p
-                    for p in range(49152, 65536)
-                    if not any(
-                        start <= p <= end
-                        for start, end in [
-                            (49752, 49851),
-                            (50000, 50059),
-                            (50060, 50159),
-                            (50160, 50259),
-                            (50260, 50359),
-                            (50914, 51013),
-                            (51114, 51213),
-                            (51214, 51313),
-                            (51314, 51413),
-                            (51623, 51722),
-                            (51723, 51822),
-                            (65269, 65368),
-                            (65369, 65468),
-                        ]
-                    )
-                ]
-            )
-        )
         return context

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -1,4 +1,5 @@
 {% raw %}# adapted from https://github.com/copier-org/copier-templates-extensions#context-hook-extension
+import random
 from typing import Any
 from typing import override
 


### PR DESCRIPTION
 ## Why is this change necessary?
Apparently the existing code wasn't actually valid Jinja...and it wasn't being caught in CI because that code doesn't execute when a default answer is supplied already


 ## How does this change address the issue?
fixes jinja syntax


 ## What side effects does this change have?
none


 ## How is this change tested?
manually instantiating a repo...not sure how to test it in CI since the answers file supplies them and it usually chokes if you don't supply an answer even when there's a default


 ## Other
bumped some pre-commit hooks and versions

sets the install_ci_tooling script to use the system version of python3 explicitly by default