### PR TITLE
Add a job to update devcontainer hash after dependabot

### DIFF
--- a/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -1,0 +1,43 @@
+{% raw %}name: Dependabot Post-Update
+permissions:
+  contents: write        # grant write access so we can push commits
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  post-update:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+        with:
+          persist-credentials: true   # (default) makes GITHUB_TOKEN available for git push
+
+      - name: Install latest versions of python packages
+        uses: ./.github/actions/install_deps_uv
+        with:
+          python-version: {% endraw %}{{ python_version }}{% raw %}
+
+      - name: Configure Git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update devcontainer hash
+        run: python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update
+
+      - name: Commit & push changes
+        run: |
+          # only commit if there are changes
+          if ! git diff --quiet; then
+            git add .
+            git commit -m "chore: apply post-Dependabot script changes"
+            git push
+          else
+            echo "No changes to commit"
+          fi{% endraw %}

--- a/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -18,11 +18,6 @@ jobs:
         with:
           persist-credentials: true   # (default) makes GITHUB_TOKEN available for git push
 
-      - name: Install latest versions of python packages
-        uses: ./.github/actions/install_deps_uv
-        with:
-          python-version: {% endraw %}{{ python_version }}{% raw %}
-
       - name: Configure Git author
         run: |
           git config user.name "github-actions[bot]"

--- a/template/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -1,0 +1,1 @@
+../../../.github/workflows/dependabot-post-update.yaml.jinja-base


### PR DESCRIPTION
 ## Link to Issue or Message thread
https://github.com/LabAutomationAndScreening/copier-python-package-template/actions/runs/14927319016


 ## Why is this change necessary?
otherwise CI will fail pre-commit checks


 ## How does this change address the issue?
Adds a job to run on dependabot branches to update devcontainer hash


 ## What side effects does this change have?
N/A


 ## How is this change tested?
can't until merge
