### PR TITLE
Exit code zero during dependabot update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 6e914d10 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 288e724c # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 288e724c # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 63011ca4 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4a4a8b75 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 6e914d10 # spellchecker:disable-line
 }

--- a/src/hash_git_files.py
+++ b/src/hash_git_files.py
@@ -171,9 +171,10 @@ def main():
             print(  # noqa: T201
                 f"Updated {devcontainer_json_file} with the new hash: {overall_checksum_str}"
             )
-            sys.exit(  # Exit with non-zero code to indicate changes were made (unless suppressed)
-                int(not args.exit_zero)
-            )
+            if args.exit_zero:
+                sys.exit(0)  # Exit with code 0 as changes are suppressed
+            else:
+                sys.exit(1)  # Exit with non-zero code to indicate changes were made
 
     else:
         print(overall_checksum_str)  # noqa: T201 # print this so that the value can be picked up via STDOUT when calling this in a CI pipeline or as a subprocess

--- a/src/hash_git_files.py
+++ b/src/hash_git_files.py
@@ -171,8 +171,10 @@ def main():
             print(  # noqa: T201
                 f"Updated {devcontainer_json_file} with the new hash: {overall_checksum_str}"
             )
-            if not args.exit_zero:
-                sys.exit(1)  # Exit with non-zero code to indicate changes were made
+            sys.exit(  # Exit with non-zero code to indicate changes were made (unless suppressed)
+                int(not args.exit_zero)
+            )
+
     else:
         print(overall_checksum_str)  # noqa: T201 # print this so that the value can be picked up via STDOUT when calling this in a CI pipeline or as a subprocess
 

--- a/src/hash_git_files.py
+++ b/src/hash_git_files.py
@@ -172,9 +172,9 @@ def main():
                 f"Updated {devcontainer_json_file} with the new hash: {overall_checksum_str}"
             )
             if args.exit_zero:
-                sys.exit(0)  # Exit with code 0 as changes are suppressed
+                sys.exit(0)
             else:
-                sys.exit(1)  # Exit with non-zero code to indicate changes were made
+                sys.exit(1)
 
     else:
         print(overall_checksum_str)  # noqa: T201 # print this so that the value can be picked up via STDOUT when calling this in a CI pipeline or as a subprocess

--- a/src/hash_git_files.py
+++ b/src/hash_git_files.py
@@ -138,6 +138,7 @@ def main():
         action="store_true",
         help="Update the hash in the devcontainer.json file based on all files relevant to devcontainer context",
     )
+    _ = parser.add_argument("--exit-zero", action="store_true", help="Exit with code 0 even if the hash changes")
     args = parser.parse_args()
 
     repo_path = args.folder
@@ -170,7 +171,8 @@ def main():
             print(  # noqa: T201
                 f"Updated {devcontainer_json_file} with the new hash: {overall_checksum_str}"
             )
-            sys.exit(1)  # Exit with non-zero code to indicate changes were made
+            if not args.exit_zero:
+                sys.exit(1)  # Exit with non-zero code to indicate changes were made
     else:
         print(overall_checksum_str)  # noqa: T201 # print this so that the value can be picked up via STDOUT when calling this in a CI pipeline or as a subprocess
 

--- a/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -10,7 +10,7 @@ on:
 jobs:
   post-update:
     if: ${{ github.actor == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
 
     steps:
       - name: Checkout code
@@ -24,7 +24,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Update devcontainer hash
-        run: python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update
+        run: python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update --exit-zero
 
       - name: Commit & push changes
         run: |


### PR DESCRIPTION
 ## Why is this change necessary?
CI run fails when devcontainer hash updates during dependabot job


 ## How does this change address the issue?
Adds option to not throw the exit code


 ## What side effects does this change have?
N/A


 ## How is this change tested?
Can't until merge

