### PR TITLE
fix: More triggers

### DIFF
--- a/extensions/context.py
+++ b/extensions/context.py
@@ -52,6 +52,7 @@ class ContextUpdater(ContextHook):
         #######
         context["gha_upload_artifact"] = "v4.6.2"
         context["gha_download_artifact"] = "v4.2.1"
+        context["gha_github_script"] = "v7.0.1"
         context["gha_setup_buildx"] = "v3.10.0"
         context["buildx_version"] = "v0.22.0"
         context["gha_docker_build_push"] = "v6.15.0"

--- a/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -33,8 +33,26 @@ jobs:
           # only commit if there are changes
           if ! git diff --quiet; then
             git add .
-            git commit -m "chore: apply post-Dependabot script changes"
+            git commit -m "chore: apply post-Dependabot script changes [dependabot skip]"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           else
             echo "No changes to commit"
-          fi{% endraw %}
+          fi
+
+      - name: Dispatch CI on PR branch # pushes done by GITHUB_TOKEN don't trigger workflows, so we have to restart the CI job manually
+        uses: actions/github-script@{% endraw %}{{ gha_github_script }}{% raw %}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = context.payload.workflow_run;
+            const pr = run.pull_requests[0];
+            if (!pr) {
+              console.log("No PR linked to this run, skipping.");
+              return;
+            }
+            await github.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "ci.yaml",
+              ref: run.head_branch,
+            });{% endraw %}

--- a/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -1,6 +1,7 @@
 {% raw %}name: Dependabot Post-Update
 permissions:
-  contents: write        # grant write access so we can push commits
+  contents: write  # so the commit can be pushed
+  actions: write   # so createWorkflowDispatch can be invoked
 on:
   pull_request:
     types: [opened, synchronize]

--- a/template/.github/workflows/dependabot-post-update.yaml.jinja-base
+++ b/template/.github/workflows/dependabot-post-update.yaml.jinja-base
@@ -48,8 +48,7 @@ jobs:
             const run = context.payload.workflow_run;
             const pr = run.pull_requests[0];
             if (!pr) {
-              console.log("No PR linked to this run, skipping.");
-              return;
+              throw new Error("No pull request linked to this workflow_run event; aborting dispatch.");
             }
             await github.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -49,6 +49,7 @@ class ContextUpdater(ContextHook):
         context["gha_cache"] = "{{ gha_cache }}"
         context["gha_upload_artifact"] = "{{ gha_upload_artifact }}"
         context["gha_download_artifact"] = "{{ gha_download_artifact }}"
+        context["gha_github_script"] = "{{ gha_github_script }}"
         context["gha_setup_buildx"] = "{{ gha_setup_buildx }}"
         context["buildx_version"] = "{{ buildx_version }}"
         context["gha_docker_build_push"] = "{{ gha_docker_build_push }}"


### PR DESCRIPTION
 ## Why is this change necessary?
The CI job won't be re-triggered by the GITHUB_TOKEN push


 ## How does this change address the issue?
uses a github script to trigger it


