### PR TITLE
Pre commit reusable workflow

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -21,52 +21,9 @@ jobs:
 
   pre-commit:
     needs: [ get-values ]
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - "{% endraw %}{{ gha_linux_runner }}{% raw %}"
-        python-version:
-            - {% endraw %}{{ python_version }}{% raw %}{% endraw %}{% if template_uses_javascript %}{% raw %}
-        node-version:
-            - 22.14.0{% endraw %}{% endif %}{% raw %}
-    name: Pre-commit for Py${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
-        with:
-          ref: ${{ github.ref_name }} # explicitly get the head of
-
-{% endraw %}{% if template_uses_javascript %}{% raw %}      - name: Setup node
-        uses: actions/setup-node@{% endraw %}{{ gha_setup_node }}{% raw %}
-        with:
-          node-version: ${{ matrix.node-version }}{% endraw %}{% endif %}{% raw %}
-
-      - name: Install latest versions of python packages
-        uses: ./.github/actions/install_deps_uv
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
-        if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
-        uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
-        with:
-          branch: mutex-venv-${{ matrix.os }}-${{ matrix.python-version }}
-        timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
-
-      - name: Cache Pre-commit hooks
-        uses: actions/cache@{% endraw %}{{ gha_cache }}{% raw %}
-        env:
-          cache-name: cache-pre-commit-hooks
-        with:
-          path: ${{ env.PRE_COMMIT_HOME }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-build-${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-build-${{ env.cache-name }}-
-
-      - name: Run pre-commit
-        run:  pre-commit run -a
+    uses: ./.github/workflows/pre-commit.yaml
+    with:
+      python-version: {% endraw %}{{ python_version }}{% raw %}
 
   lint-matrix:
     needs: [ pre-commit ]

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -26,8 +26,7 @@ permissions:
 jobs:
   pre-commit:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
-    name: Pre-commit for Py${{ matrix.python-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Pre-commit
     steps:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -1,0 +1,66 @@
+{% raw %}name: Pre-commit
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: 'What version of python'
+        type: string
+        required: true
+      setup-node:
+        description: 'Whether to set up Node'
+        type: boolean
+        default: false
+      node-version:
+        description: 'What version of node'
+        type: string
+        required: false
+        default: 'notUsing'
+
+env:
+  PYTHONUNBUFFERED: True
+
+permissions:
+    contents: write # needed for mutex
+
+jobs:
+  pre-commit:
+    runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
+    name: Pre-commit for Py${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+        with:
+          ref: ${{ github.ref_name }} # explicitly get the head of
+
+      - name: Setup node
+        uses: actions/setup-node@{% endraw %}{{ gha_setup_node }}{% raw %}
+        if: ${{ inputs.setup-node }}
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Install latest versions of python packages
+        uses: ./.github/actions/install_deps_uv
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
+        if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
+        uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
+        with:
+          branch: mutex-venv-{% endraw %}{{ gha_linux_runner }}{% raw %}-py${{ inputs.python-version }}-nodejs-${{ inputs.node-version }}
+        timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
+
+      - name: Cache Pre-commit hooks
+        uses: actions/cache@{% endraw %}{{ gha_cache }}{% raw %}
+        env:
+          cache-name: cache-pre-commit-hooks
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: {% endraw %}{{ gha_linux_runner }}{% raw %}-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            {% endraw %}{{ gha_linux_runner }}{% raw %}-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-${{ env.cache-name }}-
+
+      - name: Run pre-commit
+        run:  pre-commit run -a{% endraw %}

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -19,6 +19,7 @@ on:
 
 env:
   PYTHONUNBUFFERED: True
+  PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
     contents: write # needed for mutex

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
         with:
-          ref: ${{ github.ref_name }} # explicitly get the head of
+          ref: ${{ github.ref_name }} # explicitly get the head of the branch, which will include any new commits pushed if this is a dependabot branch
 
       - name: Setup node
         uses: actions/setup-node@{% endraw %}{{ gha_setup_node }}{% raw %}

--- a/template/template/.github/dependabot.yml.jinja
+++ b/template/template/.github/dependabot.yml.jinja
@@ -12,6 +12,10 @@ updates:
       - dependency-name: "boto3" # boto3 gets patch updates way too frequently and they're usually not important
         update-types:
           - "version-update:semver-patch"
+      - dependency-name: "sphinx*" # read-the-docs uses specific versions of sphinx, so we generally want to stay tightly pinned unless there's a major version change
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
     groups:
       prod-dependencies:

--- a/template/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -1,0 +1,1 @@
+../../../.github/workflows/pre-commit.yaml.jinja-base


### PR DESCRIPTION
 ## Why is this change necessary?
needed to DRY to stop bugs


 ## How does this change address the issue?
creates reusable workflow


 ## What side effects does this change have?
N/A


 ## How is this change tested?
child and grandchild repos


 ## Other
added ignore sphinx minor versions to generic dependabot config