### PR TITLE
explicit x64 base image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
 # base image tags available at https://mcr.microsoft.com/v2/devcontainers/universal/tags/list
-FROM mcr.microsoft.com/vscode/devcontainers/universal:2.13.1-focal
+# added the platform flag to override any local settings since this image is only compatible with linux/amd64. since this image is only x64 compatible, suppressing the hadolint rule
+# hadolint ignore=DL3029
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/universal:2.13.1-focal
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -58,5 +58,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 72ad4bb3 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 49899af4 # spellchecker:disable-line
 }


### PR DESCRIPTION
 ## Why is this change necessary?
some users experiencing issues where codespaces was trying to pull an ARM version of this image


 ## How does this change address the issue?
explicitly sets the platform to x64 in dockerfile (since image is only compatible with that)


 ## What side effects does this change have?
N/A


 ## How is this change tested?
downstream repos


 ## Other
also points to newer path for the images in the microsoft container registry