### PR TITLE
More flexible Pulumi mutex

### DIFF
--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -90,7 +90,7 @@ jobs:
   pulumi:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
     env:
-      GITHUB_IAC_API_TOKEN: {{ secrets.GITHUB_IAC_ API_TOKEN }} # only used in non-enterprise situations when not using full fledged Secrets Manager
+      GITHUB_IAC_API_TOKEN: ${{ secrets.GITHUB_IAC_ API_TOKEN }} # only used in non-enterprise situations when not using full fledged Secrets Manager
     steps:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}

--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -90,7 +90,7 @@ jobs:
   pulumi:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
     env:
-      GITHUB_IAC_API_TOKEN: ${{ secrets.GITHUB_IAC_ API_TOKEN }} # only used in non-enterprise situations when not using full fledged Secrets Manager
+      GITHUB_IAC_API_TOKEN: ${{ secrets.GITHUB_IAC_API_TOKEN }} # only used in non-enterprise situations when not using full fledged Secrets Manager
     steps:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}

--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -71,6 +71,11 @@ on:
         required: false
         default: '.'
         type: string
+      ADDITIONAL_MUTEX_SUFFIX:
+        required: false
+        default: ''
+        type: string
+        description: additional text to add on to the mutex branch name to determine more specific locking beyond just the stack name
 
 
 env:
@@ -98,7 +103,7 @@ jobs:
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
         uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
         with:
-          branch: mutex-pulumi-${{ inputs.PULUMI_STACK_NAME }}
+          branch: mutex-pulumi-${{ inputs.PULUMI_STACK_NAME }}-${{ ADDITIONAL_MUTEX_SUFFIX }}
         timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       - name: Pulumi Initial Destroy to cleanup any leftovers

--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -72,10 +72,10 @@ on:
         default: '.'
         type: string
       ADDITIONAL_MUTEX_SUFFIX:
+        description: 'additional text to add on to the mutex branch name to determine more specific locking beyond just the stack name'
         required: false
         default: ''
         type: string
-        description: additional text to add on to the mutex branch name to determine more specific locking beyond just the stack name
 
 
 env:
@@ -105,7 +105,7 @@ jobs:
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
         uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
         with:
-          branch: mutex-pulumi-${{ inputs.PULUMI_STACK_NAME }}-${{ ADDITIONAL_MUTEX_SUFFIX }}
+          branch: mutex-pulumi-${{ inputs.PULUMI_STACK_NAME }}-${{ inputs.ADDITIONAL_MUTEX_SUFFIX }}
         timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
       - name: Pulumi Initial Destroy to cleanup any leftovers

--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -89,6 +89,8 @@ permissions:
 jobs:
   pulumi:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
+    env:
+      GITHUB_IAC_API_TOKEN: {{ secrets.GITHUB_IAC_ API_TOKEN }} # only used in non-enterprise situations when not using full fledged Secrets Manager
     steps:
       - name: Checkout code
         uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}


### PR DESCRIPTION
 ## Why is this change necessary?
Sometimes just the stack name was making the mutex too restrictive in the pulumi-aws CI workflow


 ## How does this change address the issue?
Adds additional parameter to customize mutex


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo


 ## Other
Added picking up github API token secret from envvar