### PR TITLE
Update readme to use manual-install-deps instead of just a single `uv lock`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): b72624ea # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 01213271 # spellchecker:disable-line
 }

--- a/.devcontainer/manual-setup-deps.py
+++ b/.devcontainer/manual-setup-deps.py
@@ -58,8 +58,8 @@ def main():
     is_windows = platform.system() == "Windows"
     uv_env = dict(os.environ)
     uv_env.update({"UV_PYTHON_PREFERENCE": "only-system", "UV_PYTHON": args.python_version})
-    skip_check_lock = args.skip_check_lock
-    if skip_check_lock and args.optionally_check_lock:
+    skip_check_lock = args.skip_check_lock or args.optionally_check_lock
+    if args.skip_check_lock and args.optionally_check_lock:
         print("Cannot skip and optionally check the lock file at the same time.")
         sys.exit(1)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 1. Inside that devcontainer, run `python .devcontainer/install-ci-tooling.py` to install necessary tooling to instantiate the template (you can copy/paste the script from this repo...and you can paste it in the root of the repo if you want)
 1. Delete all files currently in the repository. Optional...but makes it easiest to avoid git conflicts.
 1. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-base-template.git .`
-1. Run `uv lock` to generate the lock file
+1. Run `python .devcontainer/manual-setup-deps.py --optionally-check-lock` to generate the lock file(s)
 1. Stage all files to prepare for commit (`git add .`)
 1. Run `python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update` to update the hash for your devcontainer file
 1. Commit the changes (optional)

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -17,7 +17,7 @@ class ContextUpdater(ContextHook):
         context["copier_version"] = "9.8.0"
         context["copier_template_extensions_version"] = "0.3.2"
         #######
-        context["pnpm_version"] = "10.13.1"
+        context["pnpm_version"] = "10.14.0"
         # These are duplicated in the pyproject.toml of this repository
         context["pyright_version"] = "1.1.403"
         context["pytest_version"] = "8.4.1"
@@ -42,7 +42,7 @@ class ContextUpdater(ContextHook):
         context["lab_auto_pulumi_version"] = "0.1.15"
         #######
         context["nuxt_ui_version"] = "^3.3.0"
-        context["nuxt_version"] = "^3.17.7"
+        context["nuxt_version"] = "^3.18.0"
         context["typescript_version"] = "^5.8.2"
         context["dot_env_cli_version"] = "^9.0.0"
         context["playwright_version"] = "^1.52.0"

--- a/template/README.md.jinja-base
+++ b/template/README.md.jinja-base
@@ -10,7 +10,7 @@ To create a new repository using this template:
 1. Inside that devcontainer, run `python .devcontainer/install-ci-tooling.py` to install necessary tooling to instantiate the template (you can copy/paste the script from this
 1. Delete all files currently in the repository. Optional...but makes it easiest to avoid git conflicts.
 1. Run copier to instantiate the template: `copier copy --trust gh:{% endraw %}{{ repo_org_name }}/{{ repo_name }}{% raw %}.git .`
-1. Run `uv lock` to generate the lock file
+1. Run `python .devcontainer/manual-setup-deps.py --optionally-check-lock` to generate the lock file(s)
 1. Stage all files to prepare for commit (`git add .`)
 1. Run `python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update` to update the hash for your devcontainer file
 1. Commit the changes (optional)

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -131,7 +131,7 @@ _templates_suffix: .jinja
 _exclude:
     - "copier.yml"
 
-# adapted from https://github.com/copier-org/copier-templates-extensions#context-hook-extension
+# adapted from https://github.com/copier-org/copier-template-extensions#context-hook-extension
 _jinja_extensions:
-- copier_templates_extensions.TemplateExtensionLoader
+- copier_template_extensions.TemplateExtensionLoader
 - extensions/context.py:ContextUpdater{% endraw %}


### PR DESCRIPTION
 ## Why is this change necessary?
More complex downstream repos needed more than just one thing locked


 ## How does this change address the issue?
Updates readme, and fixes issue in install script


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repos


 ## Other
Bumped some context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions in README files to use a Python script for generating lock files instead of the previous command.
  * Corrected a URL and module name in template documentation comments.

* **New Features**
  * Improved lock file generation process with a new script and optional flag.

* **Bug Fixes**
  * Updated dependency versions for pnpm and Nuxt to the latest releases.

* **Chores**
  * Updated internal context hash for development container configuration.
  * Enhanced script logic to handle lock file generation flags more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->