### PR TITLE
Fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 01213271 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): c1a43272 # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import sys
 
-UV_VERSION = "0.8.3"
+UV_VERSION = "0.8.4"
 COPIER_VERSION = "9.8.0"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "0.3.2"
 PRE_COMMIT_VERSION = "4.2.0"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
 env:
   PYTHONUNBUFFERED: True
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
+  UV_PYTHON_PREFERENCE: only-system
 
 jobs:
   pre-commit:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ on:
 env:
   PYTHONUNBUFFERED: True
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
-  UV_PYTHON_PREFERENCE: only-system
 
 jobs:
   pre-commit:
@@ -74,6 +73,8 @@ jobs:
           '--data-file tests/copier_data/data2.yaml',
           ]
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,10 @@ env:
   PYTHONUNBUFFERED: True
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
-permissions:
-    id-token: write
-    contents: write # needed for mutex
-
 jobs:
   pre-commit:
+    permissions:
+      contents: write # needed for mutex
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage-report-pytest
 .mypy_cache/
 .coverage
 .coverage.*
+coverage.xml
 
 # test profiling
 prof/

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -11,7 +11,7 @@ class ContextUpdater(ContextHook):
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
         # These are duplicated in the install-ci-tooling.py script in this repository
-        context["uv_version"] = "0.8.3"
+        context["uv_version"] = "0.8.4"
         context["pre_commit_version"] = "4.2.0"
         # These also in pyproject.toml
         context["copier_version"] = "9.8.0"

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -13,8 +13,6 @@ env:
 
 permissions:
   id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
-  contents: write # needed for mutex, and updating dependabot branches
-  statuses: write # needed for updating status on Dependabot PRs
 
 jobs:
   get-values:

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -9,19 +9,23 @@ on:
 env:
   PYTHONUNBUFFERED: True
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
+  UV_PYTHON_PREFERENCE: only-system
 
 permissions:
-    id-token: write
     contents: write # needed for mutex, and updating dependabot branches
     statuses: write # needed for updating status on Dependabot PRs
 
 jobs:
   get-values:
     uses: ./.github/workflows/get-values.yaml
+    permissions:
+      contents: write # needed for updating dependabot branches
 
   pre-commit:
     needs: [ get-values ]
     uses: ./.github/workflows/pre-commit.yaml
+    permissions:
+      contents: write # needed for mutex, and updating dependabot branches
     with:
       python-version: {% endraw %}{{ python_version }}{% raw %}
 
@@ -123,6 +127,8 @@ jobs:
   required-check:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
     needs: [ lint-matrix, get-values ]
+    permissions:
+      statuses: write # needed for updating status on Dependabot PRs
     if: always()
     steps:
       - name: fail if prior job failure

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -12,8 +12,9 @@ env:
   UV_PYTHON_PREFERENCE: only-system
 
 permissions:
-    contents: write # needed for mutex, and updating dependabot branches
-    statuses: write # needed for updating status on Dependabot PRs
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: write # needed for mutex, and updating dependabot branches
+  statuses: write # needed for updating status on Dependabot PRs
 
 jobs:
   get-values:

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -9,7 +9,6 @@ on:
 env:
   PYTHONUNBUFFERED: True
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
-  UV_PYTHON_PREFERENCE: only-system
 
 permissions:
   id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
@@ -43,6 +42,8 @@ jobs:
           '--data-file tests/copier_data/data2.yaml',
           ]
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Checkout code

--- a/template/.github/workflows/get-values.yaml.jinja-base
+++ b/template/.github/workflows/get-values.yaml.jinja-base
@@ -14,7 +14,7 @@ env:
   PYTHONUNBUFFERED: True
 
 permissions:
-    contents: write # needed to push commit of new devcontainer hash for dependabot PRs
+  contents: write # needed to push commit of new devcontainer hash for dependabot PRs
 
 jobs:
   get-values:

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -23,6 +23,7 @@ env:
 
 permissions:
   contents: write # needed for mutex
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
 
 jobs:
   pre-commit:

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -22,7 +22,7 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    contents: write # needed for mutex
+  contents: write # needed for mutex
 
 jobs:
   pre-commit:

--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -87,8 +87,8 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    id-token: write
-    contents: write # needed for mutex
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: write # needed for mutex
 
 jobs:
   pulumi:


### PR DESCRIPTION
 ## Link to Issue or Message thread
https://github.com/LabAutomationAndScreening/copier-base-template/issues/77
https://github.com/LabAutomationAndScreening/copier-base-template/issues/76


 ## Why is this change necessary?
In matrix CI jobs, `uv` was using the version defined in `.python-version`, not the version of Python defined by the matrix

Also, Github permissions were being granted at the workflow level when they could be scoped more tightly to the job


 ## How does this change address the issue?
Updates to use the `UV_PYTHON` envvar to explicitly force uv to use the desired version

Updates CI workflows to better scope permissions


 ## What side effects does this change have?
None


 ## How is this change tested?
`pyalab` python library


 ## Other
added `coverage.xml` to gitignore