### PR TITLE
Fix ruff devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 5c4c6a1a # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 93018c61 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,7 +48,7 @@
         },
         "ruff.nativeServer": "on",
         // TODO: see if there's a way to specify different configurations for different folders
-        "ruff.configuration": "${workspaceFolder}/ruff-test.toml", // use the test configuration since it's less restrictive and won't show false positives and underline things
+        "ruff.configuration": "/workspaces/copier-base-template/ruff-test.toml", // use the test configuration since it's less restrictive and won't show false positives and underline things
         "[jsonc][json]": {
           "editor.defaultFormatter": "esbenp.prettier-vscode",
           "editor.formatOnSave": true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): f6db6dac # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 38726daf # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 93018c61 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 08c28c62 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
         "ms-python.python@2025.7.2025051401",
         "ms-python.vscode-pylance@2025.4.104",
         "ms-vscode-remote.remote-containers@0.414.0",
-        "charliermarsh.ruff@2025.22.0",
+        "charliermarsh.ruff@2025.24.0",
         // Misc file formats
         "bierner.markdown-mermaid@1.28.0",
         "samuelcolvin.jinjahtml@0.20.0",
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 38726daf # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 5c4c6a1a # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -6,9 +6,9 @@ import subprocess
 import sys
 
 UV_VERSION = "0.8.4"
-COPIER_VERSION = "9.8.0"
+COPIER_VERSION = "9.9.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "0.3.2"
-PRE_COMMIT_VERSION = "4.2.0"
+PRE_COMMIT_VERSION = "4.3.0"
 GITHUB_WINDOWS_RUNNER_BIN_PATH = r"C:\Users\runneradmin\.local\bin"
 parser = argparse.ArgumentParser(description="Install CI tooling for the repo")
 _ = parser.add_argument(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
 
   # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
   - repo: https://github.com/crate-ci/typos
-    rev: 392b78fe18a52790c53f42456e46124f77346842  # frozen: v1.34.0
+    rev: 7fb6e0951ad91e4772a2470012fc1ae621016b80  # frozen: v1
     hooks:
       - id: typos
         exclude:
@@ -53,7 +53,7 @@ repos:
               .*\.umd.js|
           )$
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude:
@@ -151,7 +151,7 @@ repos:
 
   # Invalid File Checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=123"]
@@ -201,7 +201,7 @@ repos:
 
   # Safety/Security Issues
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: detect-private-key
 
@@ -223,7 +223,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 3d44372123ca5e8617fdb65d9f11facd159b9e95  # frozen: v0.12.3
+    rev: 54a455f7ce629598b7535ff828fd5fb796f4b83f  # frozen: v0.12.9
     hooks:
       - id: ruff
         name: ruff-src
@@ -236,7 +236,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: f798a4a3508bcbb8ad0773ae14bf32d28dcfdcbe  # frozen: v3.3.7
+    rev: 98942ba4126a6fe1657bad77027bcc11016d16da  # frozen: v3.3.8
     hooks:
       - id: pylint
         name: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-minimum_pre_commit_version: 4.0.1
+minimum_pre_commit_version: 4.2.0
 # run `pre-commit autoupdate --freeze` to update all hooks
 default_install_hook_types: [pre-commit, post-checkout]
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,7 @@ repos:
           |
           (?x)^(
               .*/vendor_files/.*|
+              .*tests/.*/__snapshots__/.*|
           )$
       - id: end-of-file-fixer
         # the XML formatter hook doesn't leave a blank line at the end, so excluding XML files from this hook to avoid conflicts
@@ -72,6 +73,7 @@ repos:
               template/template/.copier-answers.yml.jinja|
               template/.copier-answers.yml.jinja|
               .*generated/graphql.ts|
+              .*tests/.*/__snapshots__/.*|
               .devcontainer/devcontainer-lock.json|
               .copier-answers.yml|
               .*\.xml|
@@ -86,6 +88,7 @@ repos:
               .*pyrightconfig.json|
               .*tsconfig.json|
               .*biome.jsonc|
+              .*tests/.*/__snapshots__/.*|
               .*/vendor_files/.*|
           )$
         args: [--autofix, --no-sort-keys]

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -12,9 +12,9 @@ class ContextUpdater(ContextHook):
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
         # These are duplicated in the install-ci-tooling.py script in this repository
         context["uv_version"] = "0.8.4"
-        context["pre_commit_version"] = "4.2.0"
+        context["pre_commit_version"] = "4.3.0"
         # These also in pyproject.toml
-        context["copier_version"] = "9.8.0"
+        context["copier_version"] = "9.9.1"
         context["copier_template_extensions_version"] = "0.3.2"
         #######
         context["pnpm_version"] = "10.14.0"
@@ -25,7 +25,7 @@ class ContextUpdater(ContextHook):
         context["pytest_cov_version"] = "6.2.1"
         #######
         context["sphinx_version"] = "8.1.3"
-        context["pulumi_version"] = "3.189.0"
+        context["pulumi_version"] = "3.190.0"
         context["pulumi_aws_version"] = "7.4.0"
         context["pulumi_aws_native_version"] = "1.32.0"
         context["pulumi_command_version"] = "1.1.0"

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -35,7 +35,7 @@
         "ms-python.python@2025.7.2025051401",
         "ms-python.vscode-pylance@2025.4.104",
         "ms-vscode-remote.remote-containers@0.414.0",
-        "charliermarsh.ruff@2025.22.0",
+        "charliermarsh.ruff@2025.24.0",
 {% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_vuejs is defined and template_uses_vuejs is sameas(true) %}{% raw %}
         // VueJS
         "vue.volar@2.2.8",

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -62,7 +62,7 @@
         },
         "ruff.nativeServer": "on",
         // TODO: see if there's a way to specify different configurations for different folders
-        "ruff.configuration": "${workspaceFolder}/ruff-test.toml", // use the test configuration since it's less restrictive and won't show false positives and underline things
+        "ruff.configuration": "/workspaces/{% endraw %}{{ repo_name }}{% raw %}/ruff-test.toml", // use the test configuration since it's less restrictive and won't show false positives and underline things
         "[jsonc][json][javascript][typescript][graphql][css][scss][html][vue]": {
           "editor.defaultFormatter": "esbenp.prettier-vscode",
           "editor.formatOnSave": true


### PR DESCRIPTION
 ## Why is this change necessary?
Copilot lied about using workspaceFolder, it doesn't work


 ## How does this change address the issue?
reverts to explicit path


 ## What side effects does this change have?
Things work again


 ## How is this change tested?
They worked before


 ## Other
Bumped some dependencies
Ignoring snapshots for more pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Excluded test snapshot files from formatting hooks to reduce noisy diffs.

- Chores
  - Updated devcontainer tooling and VS Code extension versions.
  - Adjusted devcontainer Ruff config path handling for templates.
  - Bumped tool versions (Copier, pre-commit, Pulumi) and refreshed pre-commit hook revisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->