### PR TITLE
Allow installing SSM Plugin on Windows

### DIFF
--- a/template/.devcontainer/install-ci-tooling.py.jinja-base
+++ b/template/.devcontainer/install-ci-tooling.py.jinja-base
@@ -31,10 +31,10 @@ _ = parser.add_argument(
     "--no-node", action="store_true", default=False, help="Do not process any environments using node package managers"
 )
 _ = parser.add_argument(
-    "--install-ssm-plugin",
+    "--skip-installing-ssm-plugin",
     action="store_true",
-    default=INSTALL_SSM_PLUGIN_BY_DEFAULT,
-    help="Install the SSM plugin for AWS CLI",
+    default=False,
+    help="Skip installing the SSM plugin for AWS CLI",
 )
 
 
@@ -117,24 +117,44 @@ def main():
                 else [cmd]
             )
             _ = subprocess.run(cmd, shell=True, check=True)
-    if args.install_ssm_plugin:
-        if is_windows:
-            raise NotImplementedError("SSM plugin installation is not implemented for Windows")
+    if INSTALL_SSM_PLUGIN_BY_DEFAULT and not args.skip_installing_ssm_plugin:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            local_package_path = Path(tmp_dir) / "session-manager-plugin.deb"
-            # Based on https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-debian-and-ubuntu.html
-            # no specific reason for that version, just pinning it for best practice
+            if is_windows:
+                local_package_path = Path(tmp_dir) / "SessionManagerPluginSetup.exe"
+                # Based on https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-windows.html
+                # no specific reason for that version, just pinning it for best practice
+                _ = subprocess.run(
+                    [
+                        "curl",
+                        "https://s3.amazonaws.com/session-manager-downloads/plugin/1.2.707.0/windows/SessionManagerPluginSetup.exe",
+                        "-o",
+                        f"{local_package_path}",
+                    ],
+                    check=True,
+                )
+                _ = subprocess.run(
+                    [str(local_package_path), "/quiet"],
+                    check=True,
+                )
+            else:
+                local_package_path = Path(tmp_dir) / "session-manager-plugin.deb"
+                # Based on https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-debian-and-ubuntu.html
+                # no specific reason for that version, just pinning it for best practice
+                _ = subprocess.run(
+                    [
+                        "curl",
+                        "https://s3.amazonaws.com/session-manager-downloads/plugin/1.2.707.0/ubuntu_64bit/session-manager-plugin.deb",
+                        "-o",
+                        f"{local_package_path}",
+                    ],
+                    check=True,
+                )
+                _ = subprocess.run(
+                    ["sudo", "dpkg", "-i", str(local_package_path)],
+                    check=True,
+                )
             _ = subprocess.run(
-                [
-                    "curl",
-                    "https://s3.amazonaws.com/session-manager-downloads/plugin/1.2.707.0/ubuntu_64bit/session-manager-plugin.deb",
-                    "-o",
-                    f"{local_package_path}",
-                ],
-                check=True,
-            )
-            _ = subprocess.run(
-                ["sudo", "dpkg", "-i", str(local_package_path)],
+                ["echo", "SSM Plugin Manager Version:"],
                 check=True,
             )
             _ = subprocess.run(

--- a/template/.github/actions/install_deps/action.yml.jinja-base
+++ b/template/.github/actions/install_deps/action.yml.jinja-base
@@ -16,6 +16,11 @@ inputs:
     default: true
     type: boolean
     description: Whether to run the setup-deps script, or just to setup basic CI tooling
+  skip-installing-ssm-plugin-manager:
+    required: false
+    default: false
+    type: boolean
+    description: Whether to explicitly skip installing the SSM Plugin manager when setting up basic CI tooling
   project-dir:
     type: string
     description: What's the relative path to the project?
@@ -60,7 +65,7 @@ runs:
 
     - name: Install tooling
       # the funky syntax is github action ternary
-      run: python .devcontainer/install-ci-tooling.py ${{ inputs.python-version == 'notUsing' && '--no-python' || '' }} ${{ inputs.node-version == 'notUsing' && '--no-node' || '' }}
+      run: python .devcontainer/install-ci-tooling.py ${{ inputs.python-version == 'notUsing' && '--no-python' || '' }} ${{ inputs.node-version == 'notUsing' && '--no-node' || '' }} ${{ inputs.skip-installing-ssm-plugin-manager && '--skip-installing-ssm-plugin' || '' }}
       shell: pwsh
 
     - name: OIDC Auth for CodeArtifact

--- a/template/.github/workflows/pre-commit.yaml.jinja-base
+++ b/template/.github/workflows/pre-commit.yaml.jinja-base
@@ -45,6 +45,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           node-version: ${{ inputs.node-version }}
+          skip-installing-ssm-plugin-manager: true
 
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
         if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -63,13 +63,13 @@ python_ci_versions:
 aws_identity_center_id:
     type: str
     help: What's the ID of your Organization's AWS Identity center, e.g. d-9145c20053?
-    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}{% raw %}}}"
+    when: "{{ python_package_registry == 'AWS CodeArtifact' or install_aws_ssm_port_forwarding_plugin {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}{% raw %}}}"
 
 aws_org_home_region:
     type: str
     help: What is the home region of the AWS Organization (where all of the central infrastructure is deployed)?
     default: us-east-1
-    when: "{{ python_package_registry == 'AWS CodeArtifact' {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}{% raw %}}}"
+    when: "{{ python_package_registry == 'AWS CodeArtifact' or install_aws_ssm_port_forwarding_plugin {% endraw %}{% if template_uses_pulumi %}{% raw %}or True {% endraw %}{% endif %}{% raw %}}}"
 
 aws_central_infrastructure_account_id:
     type: str


### PR DESCRIPTION
 ## Link to Issue or Message thread
https://github.com/LabAutomationAndScreening/copier-base-template/issues/82


 ## Why is this change necessary?
Need to use SSM Plugin in repos that run Windows in CI


 ## How does this change address the issue?
Updates installation script to be compatible with windows.  Adds flag to be able to disable installing it (e.g. for unit tests, pre-commit, etc.)


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds Windows support for automatic AWS SSM plugin installation, with OS-specific installers and a post-install version check.
  - Expands template prompts: certain AWS settings now appear when opting into the SSM port forwarding plugin.
  - Introduces a new opt-out CLI flag: --skip-installing-ssm-plugin (default: off).

- Chores
  - GitHub Action gains an optional input to skip SSM plugin installation; the pre-commit workflow now passes this flag to opt out during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->