### PR TITLE
GraphQL Codegen for Python clients

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): b8c69216 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 876d1d33 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 876d1d33 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 6f1d19b5 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 6f1d19b5 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): b9c719df # spellchecker:disable-line
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,7 @@ repos:
     rev: 65a25783d8705c6a72d9fead19c44d87b4ff03c3  # frozen: v1
     hooks:
       - id: typos
-        exclude:
-          |
+        exclude: |
           (?x)^(
               .*\.min.js|
               .*\.min.css|
@@ -56,16 +55,14 @@ repos:
     rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude:
-          |
+        exclude: |
           (?x)^(
               .*/vendor_files/.*|
               .*tests/.*/__snapshots__/.*|
           )$
       - id: end-of-file-fixer
         # the XML formatter hook doesn't leave a blank line at the end, so excluding XML files from this hook to avoid conflicts
-        exclude:
-          | # the extra trailing newline in the pull request template makes it easier to click there in the github console. The CLI that programmatically generates devcontainer-lock.json always ends the file incompatible with this hook.
+        exclude: | # the extra trailing newline in the pull request template makes it easier to click there in the github console. The CLI that programmatically generates devcontainer-lock.json always ends the file incompatible with this hook.
           (?x)^(
               .github/pull_request_template.md|
               template/.github/pull_request_template.md|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -232,21 +232,42 @@ repos:
         name: ruff-src
         args: [--fix, --config=./ruff.toml]
         files: src/.+\.py$
+        exclude: |
+          (?x)^(
+              .*/graphql_codegen/.*|
+              .*/openapi_codegen/.*|
+          )$
       - id: ruff
         name: ruff-tests
         args: [--fix, --config=./ruff-test.toml]
         files: tests?/.+\.py$
+        exclude: |
+          (?x)^(
+              .*/graphql_codegen/.*|
+              .*/openapi_codegen/.*|
+          )$
       - id: ruff-format
+        exclude: |
+          (?x)^(
+              .*/graphql_codegen/.*|
+              .*/openapi_codegen/.*|
+          )$
 
   - repo: https://github.com/pylint-dev/pylint
     rev: 98942ba4126a6fe1657bad77027bcc11016d16da  # frozen: v3.3.8
     hooks:
       - id: pylint
         name: pylint
+        # exclude the template files---duplication within them will be discovered during CI of that template instantiation
+        exclude: |
+          (?x)^(
+              .*/graphql_codegen/.*|
+              .*/openapi_codegen/.*|
+              template/.|
+          )$
         args:
           - --rcfile=./pylintrc.toml
         verbose: true
-        exclude: ^template/.* # exclude the template files---duplication within them will be discovered during CI of that template instantiation
 
   - repo: local
     hooks:
@@ -254,6 +275,11 @@ repos:
         name: pyright
         entry: bash -c "uv run pyright"
         files: '.+\.py$'
+        exclude: |
+          (?x)^(
+              .*/graphql_codegen/.*|
+              .*/openapi_codegen/.*|
+          )$
         # don't pass filenames else the command line sees them twice
         pass_filenames: false
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -260,7 +260,7 @@ repos:
           (?x)^(
               .*/graphql_codegen/.*|
               .*/openapi_codegen/.*|
-              template/.|
+              template/.*|
           )$
         args:
           - --rcfile=./pylintrc.toml

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -34,7 +34,7 @@ class ContextUpdater(ContextHook):
         context["boto3_version"] = "1.40.25"
         context["ephemeral_pulumi_deploy_version"] = "0.0.5"
         context["pydantic_version"] = "2.11.7"
-        context["pyinstaller_version"] = "6.13.0"
+        context["pyinstaller_version"] = "6.15.0"
         context["setuptools_version"] = "80.7.1"
         context["strawberry_graphql_version"] = "0.282.0"
         context["fastapi_version"] = "0.116.1"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -44,7 +44,7 @@ class ContextUpdater(ContextHook):
         context["ariadne_codegen_version"] = "0.15.2"
         #######
         context["node_version"] = "24.7.0"
-        context["nuxt_ui_version"] = "^3.3.2"
+        context["nuxt_ui_version"] = "^3.3.3"
         context["nuxt_version"] = "^4.1.0"
         context["nuxt_icon_version"] = "^2.0.0"
         context["typescript_version"] = "^5.8.2"
@@ -57,14 +57,15 @@ class ContextUpdater(ContextHook):
         context["dotenv_cli_version"] = "^10.0.0"
         context["faker_version"] = "^10.0.0"
         context["vitest_version"] = "^3.2.4"
-        context["eslint_version"] = "^9.34.0"
+        context["eslint_version"] = "^9.35.0"
         context["nuxt_eslint_version"] = "^1.9.0"
         context["zod_version"] = "^4.1.5"
         context["zod_from_json_schema_version"] = "^0.5.0"
         context["types_node_version"] = "^24.3.1"
         context["nuxt_apollo_version"] = "5.0.0-alpha.15"
-        context["graphql_codegen_cli_version"] = "^5.0.5"
-        context["graphql_codegen_typescript_version"] = "^4.1.6"
+        context["graphql_codegen_cli_version"] = "^6.0.0"
+        context["graphql_codegen_typescript_version"] = "^5.0.0"
+        context["graphql_codegen_typescript_operations_version"] = "^5.0.0"
         #######
         # These are duplicated in the CI files for this repository
         context["gha_checkout"] = "v5.0.0"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -41,6 +41,7 @@ class ContextUpdater(ContextHook):
         context["fastapi_offline_version"] = "1.7.4"
         context["uvicorn_version"] = "0.35.0"
         context["lab_auto_pulumi_version"] = "0.1.16"
+        context["ariadne_codegen_version"] = "0.15.2"
         #######
         context["node_version"] = "24.7.0"
         context["nuxt_ui_version"] = "^3.3.2"

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -10,6 +10,7 @@
     "**/.pipx_cache",
     "**/__pycache__",
     "**/vendor_files",
+    "**/graphql_codegen",
     "**/.venv",
     "**/venv"
   ],

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,6 +11,7 @@
     "**/__pycache__",
     "**/vendor_files",
     "**/graphql_codegen",
+    "**/openapi_codegen",
     "**/.venv",
     "**/venv"
   ],

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -36,6 +36,7 @@ class ContextUpdater(ContextHook):
         context["fastapi_offline_version"] = "{{ fastapi_offline_version }}"
         context["uvicorn_version"] = "{{ uvicorn_version }}"
         context["lab_auto_pulumi_version"] = "{{ lab_auto_pulumi_version }}"
+        context["ariadne_codegen_version"] = "{{ ariadne_codegen_version }}"
 
         context["node_version"] = "{{ node_version }}"
         context["nuxt_ui_version"] = "{{ nuxt_ui_version }}"

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -60,7 +60,7 @@ class ContextUpdater(ContextHook):
         context["nuxt_apollo_version"] = "{{ nuxt_apollo_version }}"
         context["graphql_codegen_cli_version"] = "{{ graphql_codegen_cli_version }}"
         context["graphql_codegen_typescript_version"] = "{{ graphql_codegen_typescript_version }}"
-        context["graphql_codegen_typescript_operations_version"] = "{{ graphql_codegen_typescript_version }}"
+        context["graphql_codegen_typescript_operations_version"] = "{{ graphql_codegen_typescript_operations_version }}"
 
         context["gha_checkout"] = "{{ gha_checkout }}"
         context["gha_setup_python"] = "{{ gha_setup_python }}"

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -60,6 +60,7 @@ class ContextUpdater(ContextHook):
         context["nuxt_apollo_version"] = "{{ nuxt_apollo_version }}"
         context["graphql_codegen_cli_version"] = "{{ graphql_codegen_cli_version }}"
         context["graphql_codegen_typescript_version"] = "{{ graphql_codegen_typescript_version }}"
+        context["graphql_codegen_typescript_operations_version"] = "{{ graphql_codegen_typescript_version }}"
 
         context["gha_checkout"] = "{{ gha_checkout }}"
         context["gha_setup_python"] = "{{ gha_setup_python }}"


### PR DESCRIPTION
 ## Why is this change necessary?
Allow easier generation of code for writing E2E tests


 ## How does this change address the issue?
Adds some excludes to pre-commit hooks to not touch the autogenerated code
Adds some versions to context.py


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated pre-commit configuration formatting; enabled typo checks for UMD bundles; excluded generated and template code from linters/type checkers to streamline development and CI.
  * Bumped versions of build/codegen tools and added missing entries to shared context for improved compatibility.
  * Adjusted type checker settings to skip generated sources.
  * Updated development container metadata.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->