### PR TITLE
Streaming output, longer timeout and shellcheck fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,5 +75,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 275b721b # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 72297353 # spellchecker:disable-line
 }

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -3,8 +3,8 @@ set -ex
 
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
-script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-repo_root="$(CDPATH= cd -- "$script_dir/.." && pwd)"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 git config --global --add safe.directory "$repo_root"
 
 sh .devcontainer/on-create-command-boilerplate.sh

--- a/.devcontainer/post-start-command.sh
+++ b/.devcontainer/post-start-command.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 # TODO: update the devcontainer hash script to exclude this file, since rebuilding the devcontainer wouldn't rely on this
-script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-repo_root="$(CDPATH= cd -- "$script_dir/.." && pwd)"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 git config --global --add safe.directory "$repo_root"
 
 pre-commit run merge-claude-settings -a

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -115,6 +115,7 @@ class ContextUpdater(ContextHook):
         context["gha_medium_timeout_minutes"] = "8"
         context["gha_long_timeout_minutes"] = "15"
         context["gha_xlong_timeout_minutes"] = "45"
+        context["gha_xxlong_timeout_minutes"] = "90"
         #######
         context["debian_release_name"] = "trixie"
         context["alpine_image_version"] = "3.23"

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -3,8 +3,8 @@ set -ex
 
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
-script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-repo_root="$(CDPATH= cd -- "$script_dir/.." && pwd)"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 git config --global --add safe.directory "$repo_root"
 
 sh .devcontainer/on-create-command-boilerplate.sh{% endraw %}{% if install_claude_cli %}{% raw %}

--- a/template/.devcontainer/post-start-command.sh.jinja-base
+++ b/template/.devcontainer/post-start-command.sh.jinja-base
@@ -3,8 +3,8 @@ set -ex
 
 # For some reason the directory is not setup correctly and causes build of devcontainer to fail since
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
-script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-repo_root="$(CDPATH= cd -- "$script_dir/.." && pwd)"
+script_dir="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+repo_root="$(CDPATH='' cd -- "$script_dir/.." && pwd)"
 git config --global --add safe.directory "$repo_root"{% endraw %}{% if install_claude_cli %}{% raw %}
 pre-commit run merge-claude-settings -a
 if ! bd ready; then

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -106,7 +106,7 @@ class ContextUpdater(ContextHook):
         context["gha_medium_timeout_minutes"] = "{{ gha_medium_timeout_minutes }}"
         context["gha_long_timeout_minutes"] = "{{ gha_long_timeout_minutes }}"
         context["gha_xlong_timeout_minutes"] = "{{ gha_xlong_timeout_minutes }}"
-        context["gha_xxlong_timeout_minutes"] = "{{"gha_xxlong_timeout_minutes"}}"
+        context["gha_xxlong_timeout_minutes"] = "{{gha_xxlong_timeout_minutes}}"
 
         context["debian_release_name"] = "{{ debian_release_name }}"
         context["alpine_image_version"] = "{{ alpine_image_version }}"

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -106,6 +106,7 @@ class ContextUpdater(ContextHook):
         context["gha_medium_timeout_minutes"] = "{{ gha_medium_timeout_minutes }}"
         context["gha_long_timeout_minutes"] = "{{ gha_long_timeout_minutes }}"
         context["gha_xlong_timeout_minutes"] = "{{ gha_xlong_timeout_minutes }}"
+        context["gha_xxlong_timeout_minutes"] = "{{"gha_xxlong_timeout_minutes"}}"
 
         context["debian_release_name"] = "{{ debian_release_name }}"
         context["alpine_image_version"] = "{{ alpine_image_version }}"

--- a/template/template/.github/actions/{% if template_uses_pulumi %}pulumi_ephemeral_deploy{% endif %}/action.yml.jinja-base
+++ b/template/template/.github/actions/{% if template_uses_pulumi %}pulumi_ephemeral_deploy{% endif %}/action.yml.jinja-base
@@ -80,8 +80,9 @@ runs:
 
     - name: Run CLI
       run: |
-        output=$(uv --directory ${{ github.workspace }}/${{ inputs.project-dir }} run python -m ${{ inputs.deploy-script-module-name }}.${{ inputs.deploy-script-name }} --stack=${{ inputs.stack-name }} ${{ inputs.cli-action }})
-        echo "$output"
+        tmp_output=$(mktemp)
+        uv --directory ${{ github.workspace }}/${{ inputs.project-dir }} run python -m ${{ inputs.deploy-script-module-name }}.${{ inputs.deploy-script-name }} --stack=${{ inputs.stack-name }} ${{ inputs.cli-action }} 2>&1 | tee "$tmp_output"
+        output=$(cat "$tmp_output")
 
         header=":eyes: **Pulumi Preview for ${{ inputs.deploy-script-module-name }} stack ${{ inputs.stack-name }}:** :eyes:"
 
@@ -94,10 +95,15 @@ runs:
         EOF
 
         if [ $(wc -c < /tmp/pulumi-preview-comment.md) -gt 65535 ]; then
+          resources_section=$(echo "$output" | sed -n '/^Resources:/,$p')
           cat > /tmp/pulumi-preview-comment.md << EOF
         $header
 
-        Output was too long to display here.
+        Output was too long to display here. Resources summary:
+
+        \`\`\`bash
+        $resources_section
+        \`\`\`
 
         [View the full output in the Actions run.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
         EOF

--- a/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
+++ b/template/template/.github/workflows/{% if template_uses_pulumi %}pulumi-aws.yml{% endif %}.jinja-base
@@ -109,7 +109,7 @@ permissions:
 jobs:
   pulumi:
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
-    timeout-minutes: {% endraw %}{{ gha_xlong_timeout_minutes }}{% raw %}
+    timeout-minutes: {% endraw %}{{ gha_xxlong_timeout_minutes }}{% raw %}
     env:
       IAC_GITHUB_API_TOKENS: ${{ secrets.iac-github-api-tokens }} # only used in non-enterprise situations when not using full fledged Secrets Manager
     steps:


### PR DESCRIPTION
## Link to Issue or Message thread
https://teams.microsoft.com/l/message/19:5da20711dcc04955b72e08a36728a0af@thread.tacv2/1776883847005?tenantId=7695572f-e242-4594-8d01-3a29a79afd28&groupId=&parentMessageId=1776883847005&teamName=LabSync%20Projects&channelName=LSP011%20-%20JnJ%20-%20Orchestration


## Why is this change necessary?
Want output to stream in pulumi preview/up commands, need longer timeout for some pulumi jobs and when pulling in downstream shellcheck found an issue with a devcontainer script. 



## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos


