### PR TITLE
Have VCRPy display diff when body matcher fails

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,5 +75,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 72297353 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 404673e1 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,7 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.18.4",
+        "coderabbit.coderabbit-vscode@0.18.5",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
         "github.copilot@1.388.0",

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -19,7 +19,7 @@ class ContextUpdater(ContextHook):
         #######
         context["pnpm_version"] = "10.33.1"
         # These are duplicated in the pyproject.toml of this repository
-        context["pyright_version"] = ">=1.1.408"
+        context["pyright_version"] = ">=1.1.409"
         context["pytest_version"] = ">=9.0.3"
         context["pytest_randomly_version"] = ">=4.1.0"
         context["pytest_cov_version"] = ">=7.1.0"
@@ -40,7 +40,7 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = ">=0.298.0"
         context["fastapi_version"] = ">=0.135.3"
         context["fastapi_offline_version"] = ">=1.7.4"
-        context["uvicorn_version"] = ">=0.44.0"
+        context["uvicorn_version"] = ">=0.46.0"
         context["lab_auto_pulumi_version"] = ">=0.2.0"
         context["ariadne_codegen_version"] = ">=0.18.0"
         context["pytest_mock_version"] = ">=3.15.1"
@@ -121,7 +121,7 @@ class ContextUpdater(ContextHook):
         context["alpine_image_version"] = "3.23"
         context["nginx_image_version"] = "1.29.4"
         #######
-        context["kiota_cli_version"] = "1.31.0"
+        context["kiota_cli_version"] = "1.31.1"
         # These also in the tests/data.yml files in this repository and in copier.yaml
         context["py312_version"] = "3.12.7"  # ReadTheDocs does not yet support 3.12.8
         context["py313_version"] = "3.13.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
-    "pyright[nodejs]>=1.1.408",
+    "pyright[nodejs]>=1.1.409",
     "ty>=0.0.32",
     "copier==9.14.3",
     "copier-template-extensions==0.3.3"

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -39,7 +39,7 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code{% endraw %}{% endif %}{% raw %}
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.18.4",
+        "coderabbit.coderabbit-vscode@0.18.5",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
         "github.copilot@1.388.0",

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -69,10 +69,15 @@ def _normalize_json(body: str) -> str:
         return body
 
 
-def _make_logging_body_matcher() -> Callable[[_VCRRequest, _VCRRequest], None]:
+def _make_logging_body_matcher(
+    *normalizers: Callable[[str], str],
+) -> Callable[[_VCRRequest, _VCRRequest], None]:
     def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
         b1 = _normalize_json(_decode_vcr_body(r1.body))
         b2 = _normalize_json(_decode_vcr_body(r2.body))
+        for normalize in normalizers:
+            b1 = normalize(b1)
+            b2 = normalize(b2)
         if b1 != b2:
             diff = "\n".join(
                 difflib.unified_diff(

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -52,19 +52,23 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
     try:
         _vcr_matchers.body(r1, r2)  # pyright: ignore[reportUnknownMemberType] # vcrpy is untyped
     except AssertionError as err:
-        b1 = _read_body_as_str(r1)
-        b2 = _read_body_as_str(r2)
-        diff = "\n".join(
-            difflib.unified_diff(
-                b2.splitlines(),
-                b1.splitlines(),
-                fromfile="cassette",
-                tofile="actual",
-                lineterm="",
+        try:
+            b1 = _read_body_as_str(r1)
+            b2 = _read_body_as_str(r2)
+            diff = "\n".join(
+                difflib.unified_diff(
+                    b2.splitlines(),
+                    b1.splitlines(),
+                    fromfile="cassette",
+                    tofile="actual",
+                    lineterm="",
+                )
             )
-        )
-        logger.info(f"VCR body mismatch:\n{diff}")
-        print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+            logger.info(f"VCR body mismatch:\n{diff}")
+            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+        except Exception:
+            logger.exception("Error while logging VCR body mismatch")
+            raise AssertionError from err
         raise AssertionError(
             f"Request body mismatch:\n{diff}"
         ) from err  # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -1,6 +1,7 @@
 import difflib
 import logging
 import os
+import traceback
 from typing import Any
 from typing import cast
 
@@ -52,6 +53,11 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
     try:
         _vcr_matchers.body(r1, r2)  # pyright: ignore[reportUnknownMemberType] # vcrpy is untyped
     except AssertionError as err:
+        tb_frames = traceback.extract_tb(err.__traceback__)
+        if (
+            not tb_frames or f"{os.sep}vcr{os.sep}" not in tb_frames[-1].filename
+        ):  # if the assertion error came from something else in pytest, just rethrow it. Only log the diff if the assertion error came from within VCRpy itself
+            raise
         try:
             b1 = _read_body_as_str(r1)
             b2 = _read_body_as_str(r2)
@@ -64,14 +70,11 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
                     lineterm="",
                 )
             )
-            logger.info(f"VCR body mismatch:\n{diff}")
-            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
         except Exception:
             logger.exception("Error while logging VCR body mismatch")
             raise AssertionError from err
-        raise AssertionError(
-            f"Request body mismatch:\n{diff}"
-        ) from err  # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
+        # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
+        raise AssertionError(f"Request body mismatch:\n{diff}") from err
 
 
 def pytest_recording_configure(

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -1,4 +1,5 @@
 import difflib
+import json
 import logging
 import os
 from collections.abc import Callable
@@ -61,15 +62,17 @@ class _VCRRequest:
     body: object
 
 
-def _make_logging_body_matcher(
-    *normalizers: Callable[[str], str],
-) -> Callable[[_VCRRequest, _VCRRequest], None]:
+def _normalize_json(body: str) -> str:
+    try:
+        return json.dumps(json.loads(body), sort_keys=True)
+    except (ValueError, TypeError):
+        return body
+
+
+def _make_logging_body_matcher() -> Callable[[_VCRRequest, _VCRRequest], None]:
     def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
-        b1 = _decode_vcr_body(r1.body)
-        b2 = _decode_vcr_body(r2.body)
-        for normalize in normalizers:
-            b1 = normalize(b1)
-            b2 = normalize(b2)
+        b1 = _normalize_json(_decode_vcr_body(r1.body))
+        b2 = _normalize_json(_decode_vcr_body(r2.body))
         if b1 != b2:
             diff = "\n".join(
                 difflib.unified_diff(

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -47,7 +47,7 @@ def _decode_vcr_body(body: object) -> str:
     if isinstance(body, str):
         return body
     if isinstance(body, BytesIO):
-        return body.read().decode("utf-8")
+        return body.getvalue().decode("utf-8")
     if isinstance(body, Iterator):
         raise NotImplementedError(
             "VCR body is an Iterator — element type is ambiguous (bytes chunks vs ints). Extend _decode_vcr_body if you need to support streaming request bodies."

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -1,9 +1,17 @@
+import difflib
+import logging
 import os
+import re
+from collections.abc import Callable
+from collections.abc import Iterator
+from io import BytesIO
 from typing import Any
 from typing import cast
 
 import pytest
 from vcr import VCR
+
+logger = logging.getLogger(__name__)
 
 UNREACHABLE_IP_ADDRESS = "192.0.2.1"  # RFC 5737 TEST-NET-1
 IGNORED_HOSTS = [
@@ -32,6 +40,48 @@ def vcr_config() -> dict[str, list[str]]:
     return cfg
 
 
+def _decode_vcr_body(body: object) -> str:
+    if body is None:
+        return ""
+    if isinstance(body, bytes):
+        return body.decode("utf-8")
+    if isinstance(body, str):
+        return body
+    if isinstance(body, BytesIO):
+        return body.read().decode("utf-8")
+    if isinstance(body, Iterator):
+        raise NotImplementedError(
+            "VCR body is an Iterator — element type is ambiguous (bytes chunks vs ints). Extend _decode_vcr_body if you need to support streaming request bodies."
+        )
+    raise TypeError(f"Unexpected VCR body type: {type(body)}")
+
+
+def _make_logging_body_matcher(
+    *normalizers: Callable[[str], str],
+) -> Callable[["_VCRRequest", "_VCRRequest"], None]:
+    def _body_matcher(r1: "_VCRRequest", r2: "_VCRRequest") -> None:
+        b1 = _decode_vcr_body(r1.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
+        b2 = _decode_vcr_body(r2.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
+        for normalize in normalizers:
+            b1 = normalize(b1)
+            b2 = normalize(b2)
+        if b1 != b2:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    b2.splitlines(),
+                    b1.splitlines(),
+                    fromfile="cassette",
+                    tofile="actual",
+                    lineterm="",
+                )
+            )
+            logger.warning("VCR body mismatch:\n%s", diff)
+            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+            raise AssertionError(f"Request body mismatch:\n{diff}")
+
+    return _body_matcher
+
+
 def pytest_recording_configure(
     config: pytest.Config,  # noqa: ARG001 # the config argument MUST be present (even when unused) or pytest-recording throws an error
     vcr: VCR,
@@ -40,7 +90,9 @@ def pytest_recording_configure(
     assert isinstance(vcr.match_on, tuple), (
         f"vcr.match_on is not a tuple, it is a {type(vcr.match_on)} with value {vcr.match_on}"
     )
-    vcr.match_on += ("body",)  # body is not included by default, but it seems relevant
+
+    vcr.register_matcher("logging_body", _make_logging_body_matcher())  # pyright: ignore[reportUnknownMemberType] # vcrpy is not fully typed
+    vcr.match_on += ("logging_body",)  # body is not included by default, but it seems relevant
 
     def before_record_response(response: dict[str, str | dict[str, Any]]) -> dict[str, str | dict[str, Any]]:
         headers_to_filter = (
@@ -62,3 +114,9 @@ def pytest_recording_configure(
         return response
 
     vcr.before_record_response = before_record_response
+
+
+class _VCRRequest:
+    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
+
+    body: object

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -1,15 +1,14 @@
 import difflib
-import json
 import logging
 import os
-from collections.abc import Callable
-from collections.abc import Iterator
-from io import BytesIO
 from typing import Any
 from typing import cast
 
 import pytest
 from vcr import VCR
+from vcr import matchers as _vcr_matchers
+from vcr.request import Request as VCRRequest
+from vcr.util import read_body as _vcr_read_body  # pyright: ignore[reportUnknownVariableType] # vcrpy is untyped
 
 logger = logging.getLogger(__name__)
 
@@ -40,59 +39,35 @@ def vcr_config() -> dict[str, list[str]]:
     return cfg
 
 
-def _decode_vcr_body(body: object) -> str:
-    if body is None:
+def _read_body_as_str(request: VCRRequest) -> str:
+    raw = _vcr_read_body(request)  # pyright: ignore[reportUnknownVariableType] # vcrpy is untyped
+    if raw is None:
         return ""
-    if isinstance(body, bytes):
-        return body.decode("utf-8")
-    if isinstance(body, str):
-        return body
-    if isinstance(body, BytesIO):
-        return body.getvalue().decode("utf-8")
-    if isinstance(body, Iterator):
-        raise NotImplementedError(
-            "VCR body is an Iterator — element type is ambiguous (bytes chunks vs ints). Extend _decode_vcr_body if you need to support streaming request bodies."
-        )
-    raise TypeError(f"Unexpected VCR body type: {type(body)}")
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8")
+    return str(raw)  # pyright: ignore[reportUnknownArgumentType] # vcrpy is untyped
 
 
-class _VCRRequest:
-    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
-
-    body: object
-
-
-def _normalize_json(body: str) -> str:
+def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
     try:
-        return json.dumps(json.loads(body), sort_keys=True)
-    except (ValueError, TypeError):
-        return body
-
-
-def _make_logging_body_matcher(
-    *normalizers: Callable[[str], str],
-) -> Callable[[_VCRRequest, _VCRRequest], None]:
-    def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
-        b1 = _normalize_json(_decode_vcr_body(r1.body))
-        b2 = _normalize_json(_decode_vcr_body(r2.body))
-        for normalize in normalizers:
-            b1 = normalize(b1)
-            b2 = normalize(b2)
-        if b1 != b2:
-            diff = "\n".join(
-                difflib.unified_diff(
-                    b2.splitlines(),
-                    b1.splitlines(),
-                    fromfile="cassette",
-                    tofile="actual",
-                    lineterm="",
-                )
+        _vcr_matchers.body(r1, r2)  # pyright: ignore[reportUnknownMemberType] # vcrpy is untyped
+    except AssertionError as err:
+        b1 = _read_body_as_str(r1)
+        b2 = _read_body_as_str(r2)
+        diff = "\n".join(
+            difflib.unified_diff(
+                b2.splitlines(),
+                b1.splitlines(),
+                fromfile="cassette",
+                tofile="actual",
+                lineterm="",
             )
-            logger.warning("VCR body mismatch:\n%s", diff)
-            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
-            raise AssertionError(f"Request body mismatch:\n{diff}")
-
-    return _body_matcher
+        )
+        logger.info(f"VCR body mismatch:\n{diff}")
+        print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+        raise AssertionError(
+            f"Request body mismatch:\n{diff}"
+        ) from err  # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
 
 
 def pytest_recording_configure(
@@ -104,7 +79,7 @@ def pytest_recording_configure(
         f"vcr.match_on is not a tuple, it is a {type(vcr.match_on)} with value {vcr.match_on}"
     )
 
-    vcr.register_matcher("logging_body", _make_logging_body_matcher())  # pyright: ignore[reportUnknownMemberType] # vcrpy is not fully typed
+    vcr.register_matcher("logging_body", _logging_body_matcher)  # pyright: ignore[reportUnknownMemberType] # vcrpy is not fully typed
     vcr.match_on += ("logging_body",)  # body is not included by default, but it seems relevant
 
     def before_record_response(response: dict[str, str | dict[str, Any]]) -> dict[str, str | dict[str, Any]]:

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -72,7 +72,7 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
             )
         except Exception:
             logger.exception("Error while logging VCR body mismatch")
-            raise AssertionError from err
+            raise err from None  # if there's some failure generating the diff, just raise the original error unchanged
         # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
         raise AssertionError(f"Request body mismatch:\n{diff}") from err
 

--- a/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
+++ b/template/copier_template_resources/{% if template_might_want_to_use_vcrpy %}vcrpy_fixtures.py{% endif %}
@@ -1,7 +1,6 @@
 import difflib
 import logging
 import os
-import re
 from collections.abc import Callable
 from collections.abc import Iterator
 from io import BytesIO
@@ -56,12 +55,18 @@ def _decode_vcr_body(body: object) -> str:
     raise TypeError(f"Unexpected VCR body type: {type(body)}")
 
 
+class _VCRRequest:
+    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
+
+    body: object
+
+
 def _make_logging_body_matcher(
     *normalizers: Callable[[str], str],
-) -> Callable[["_VCRRequest", "_VCRRequest"], None]:
-    def _body_matcher(r1: "_VCRRequest", r2: "_VCRRequest") -> None:
-        b1 = _decode_vcr_body(r1.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
-        b2 = _decode_vcr_body(r2.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
+) -> Callable[[_VCRRequest, _VCRRequest], None]:
+    def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
+        b1 = _decode_vcr_body(r1.body)
+        b2 = _decode_vcr_body(r2.body)
         for normalize in normalizers:
             b1 = normalize(b1)
             b2 = normalize(b2)
@@ -114,9 +119,3 @@ def pytest_recording_configure(
         return response
 
     vcr.before_record_response = before_record_response
-
-
-class _VCRRequest:
-    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
-
-    body: object

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = "==9.14.3" },
     { name = "copier-template-extensions", specifier = "==0.3.3" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.408" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
@@ -386,15 +386,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why is this change necessary?
It's hard to troubleshoot a problem just getting a message "body didn't match"


## How does this change address the issue?
Adds in displaying the actual diff


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos


## Other
Bumped some versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated devcontainer extension and bumped development tool version constraints for improved compatibility and reliability.

* **Tests**
  * Enhanced test cassette matching with a custom body matcher that produces clearer diffs and improved logging for request-body mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->