### PR TITLE
Add check for copier answers file

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -83,6 +83,11 @@ template_publishes_releases:
     help: Does this template publish versioned releases (e.g. to PyPI, npm, or a container registry)?
     default: no
 
+copier_answers_directory:
+    type: str
+    help: What directory within the instantiated template contains the .copier-answers.yml file? Use '.' for the root, or a subdirectory path (e.g. 'frontend').
+    default: "."
+
 _tasks:
   - command: |
         python3 '{{ _copier_conf.src_path }}/src/copier_tasks/remove_precommit_hooks.py' \

--- a/template/.github/workflows/ci.yaml.jinja-base
+++ b/template/.github/workflows/ci.yaml.jinja-base
@@ -127,6 +127,14 @@ jobs:
       - name: Instantiate copier template
         run: |
           copier copy --trust --vcs-ref ${{ github.sha }} ${{ matrix.copier }} --data python_version=${{ matrix.python-version }} . ./new-template
+
+      - name: Confirm instantiated template has copier answers file
+        run: |
+          if [ ! -f "./new-template/{% endraw %}{{ copier_answers_directory }}{% raw %}/.copier-answers.yml" ]; then
+            echo "Copier answers file not found in instantiated template location"
+            exit 1
+          fi
+
       - name: Delete files from initial repo
         run: |
           # Delete everything except the folder containing the instantiated template
@@ -137,6 +145,7 @@ jobs:
           rm -rf .devcontainer # apparently this folder doesn't get removed with the previous command for some reason
           rm -rf .claude # apparently this folder doesn't get removed with the previous command for some reason
           ls -la
+
       - name: Move the instantiated template into the repo root
         run: |
           # Move all the files from the instantiated template out of the subfolder

--- a/template/copier.yml.jinja-base
+++ b/template/copier.yml.jinja-base
@@ -3,7 +3,6 @@
 
 
 
-
 # Questions managed by upstream template
 repo_name:
     type: str
@@ -143,6 +142,11 @@ aws_region_for_stack:
     default: "{{ aws_org_home_region }}"
 
 {% endraw %}{% endif %}{% raw %}
+
+copier_answers_directory:
+    type: str
+    help: What directory within the instantiated template contains the .copier-answers.yml file? Use '.' for the root, or a subdirectory path (e.g. 'frontend').
+    default: "."
 
 # Questions specific to this template
 

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -14,3 +14,4 @@ template_might_want_to_install_aws_ssm_port_forwarding_plugin: true
 template_might_want_to_use_vcrpy: false
 template_might_want_to_use_python_asyncio: true
 template_publishes_releases: true
+copier_answers_directory: .

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -16,3 +16,4 @@ template_might_want_to_install_aws_ssm_port_forwarding_plugin: false
 template_might_want_to_use_vcrpy: true
 template_might_want_to_use_python_asyncio: false
 template_publishes_releases: false
+copier_answers_directory: .


### PR DESCRIPTION
## Link to Issue or Message thread
DM with Eli


## Why is this change necessary?
We are seeing cases where if you update the base template for some reason the copier-answers.yml could be deleted as part of it. If its not caught during the merge you end up with a copier template that works but it never persists your answers. See current template for copier-circuit-python-device-driver-frontend https://github.com/lab-sync/copier-circuit-python-device-driver-frontend/tree/2008bd623575f9cafa7a5d7037d35c30e7ac3944/template where this happened


## How does this change address the issue?
Adds a test that ensures that if we do in fact miss it that we wont get past CI anymore


## What side effects does this change have?
N/A


## How is this change tested?
CI downstream https://github.com/lab-sync/copier-circuit-python-device-driver-frontend/actions/runs/26227704302/job/77179327225 this is a backport and making it generic.

As well as in backend template see PR here. https://github.com/lab-sync/copier-circuit-python-device-driver-backend/pull/18



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to specify the directory location of template answer files, with a default root directory setting.

* **Tests**
  * Updated test data to include the new configuration parameter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LabAutomationAndScreening/copier-base-template/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->