### PR TITLE
Adds k3ds version

### DIFF
--- a/extensions/context.py
+++ b/extensions/context.py
@@ -113,6 +113,7 @@ class ContextUpdater(ContextHook):
         context["gha_pypi_publish"] = "v1.14.0"
         context["gha_sleep"] = "v2.0.3"
         context["gha_absaoss_k3d"] = "v2.4.0"
+        context["k3d_version"] = "v5.5.0"
         context["gha_azure_setup_helm"] = "v5.0.0"
         context["helm_version"] = "v3.18.3"
         context["gha_azure_setup_kubectl"] = "v5.1.0"

--- a/template/extensions/context.py.jinja-base
+++ b/template/extensions/context.py.jinja-base
@@ -105,6 +105,7 @@ class ContextUpdater(ContextHook):
         context["gha_pypi_publish"] = "{{ gha_pypi_publish }}"
         context["gha_sleep"] = "{{ gha_sleep }}"
         context["gha_absaoss_k3d"] = "{{ gha_absaoss_k3d }}"
+        context["k3d_version"] = "{{ k3d_version }}"
         context["gha_azure_setup_helm"] = "{{ gha_azure_setup_helm }}"
         context["helm_version"] = "{{ helm_version }}"
         context["gha_azure_setup_kubectl"] = "{{ gha_azure_setup_kubectl }}"


### PR DESCRIPTION
## Link to Issue or Message thread
https://github.com/LabAutomationAndScreening/copier-nuxt-python-intranet-app/pull/177


## Why is this change necessary?
k3ds install script is now checking for checksums.txt. The version that is pinned in the action 5.4.6 does not have that file. Thus resulting in the install script failing with a 404.



## How does this change address the issue?
add k3d_version v5.5.0 context var alongside gha_absaoss_k3d. Propagates downstream for use in other copier templates.


## What side effects does this change have?
Working k3ds test downstream


## How is this change tested?
Downstream

