### PR TITLE
Guard against malicous commit messages

### DIFF
--- a/template/.github/workflows/get-values.yaml.jinja-base
+++ b/template/.github/workflows/get-values.yaml.jinja-base
@@ -49,12 +49,19 @@ jobs:
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
         id: find-pr-num
         # Based on https://github.com/actions/checkout/issues/58#issuecomment-847922894
+        env:
+          MERGE_MSG: ${{ github.event.merge_group.head_commit.message }}
         run: |
 
           [[ '${{ github.event_name }}' = 'pull_request' ]] && full_number=${{ github.event.number }}
 
           # example message in merge group context: "Merge pull request #10 from org-name/branch-name\n\ncommit message"
-          [[ '${{ github.event_name }}' = 'merge_group' ]] && message='${{ github.event.merge_group.head_commit.message }}' && echo Extracting from $message && number_and_following_text=${message##*#} && full_number=${number_and_following_text%%[!0-9]*}
+          if [[ '${{ github.event_name }}' = 'merge_group' ]]; then
+            message="$MERGE_MSG"
+            echo "Extracting from $message"
+            number_and_following_text="${message##*#}"
+            full_number="${number_and_following_text%%[!0-9]*}"
+          fi
 
           short_number=${full_number:${#full_number}<2?0:-2} # only use the last two digits so that the stack name is no more than 7 characters and doesn't get too long. Based on https://stackoverflow.com/questions/19858600/accessing-last-x-characters-of-a-string-in-bash
 


### PR DESCRIPTION
## Link to Issue or Message thread
Downstream finding


## Why is this change necessary?
If using merge groups its possible a commit message that was malicious could do script injection since it was interpolated directly.


## How does this change address the issue?
Uses environment variables so the interpolation doesn't happen directly in the script


## What side effects does this change have?
N/A


## How is this change tested?
TBD since we are not using merge queues yet

