### PR TITLE
Use uv to install python

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -14,11 +14,6 @@
       "version": "1.2.5",
       "resolved": "ghcr.io/devcontainers/features/git-lfs@sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72",
       "integrity": "sha256:71c2b371cf12ab7fcec47cf17369c6f59156100dad9abf9e4c593049d789de72"
-    },
-    "ghcr.io/devcontainers/features/python:1.8.0": {
-      "version": "1.8.0",
-      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
-      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,12 +18,6 @@
       // view latest version https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
       "version": "2.34.34"
     },
-    "ghcr.io/devcontainers/features/python:1.8.0": {
-      // https://github.com/devcontainers/features/blob/main/src/python/devcontainer-feature.json
-      "version": "3.12.7",
-      "installTools": false,
-      "optimize": false
-    },
     // https://github.com/anthropics/devcontainer-features/blob/main/src/claude-code/devcontainer-feature.json
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5": {}
   },
@@ -34,15 +28,13 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.19.2",
+        "coderabbit.coderabbit-vscode@0.20.0",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
-        "github.copilot@1.388.0",
-        "github.copilot-chat@0.44.2",
-        "anthropic.claude-code@2.1.145",
+        "anthropic.claude-code@2.1.169",
         // Python
-        "ms-python.python@2026.5.2026032701",
-        "ms-python.vscode-pylance@2026.2.100",
+        "ms-python.python@2026.5.2026052901",
+        "meta.pyrefly@1.0.0",
         "ms-vscode-remote.remote-containers@0.414.0",
         "charliermarsh.ruff@2026.44.0",
         // Misc file formats
@@ -75,5 +67,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): d3b45725 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 66b40702 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,5 +67,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 66b40702 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 8e3f0706 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,5 +67,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 8e3f0706 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): ef40c66c # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -5,8 +5,8 @@ import shutil
 import subprocess
 import sys
 
-UV_VERSION = "0.11.17"
-PNPM_VERSION = "11.5.0"
+UV_VERSION = "0.11.19"
+PNPM_VERSION = "11.5.2"
 COPIER_VERSION = "9.15.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "0.3.3"
 PRE_COMMIT_VERSION = "4.5.1"

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -17,6 +17,6 @@ npm --prefix "$repo_root/.claude" ci
 # Install beads for use in Claude planning
 npm install -g @beads/bd@0.57.0 # no specific reason for this version, just pinning for best practice
 
-python .devcontainer/manual-setup-deps.py --optionally-check-lock
+python .devcontainer/manual-setup-deps.py --optionally-check-lock --allow-uv-to-install-python
 
 pre-commit install --install-hooks

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -13,9 +13,9 @@ class ContextUpdater(ContextHook):
         self, context: dict[Any, Any]
     ) -> dict[Any, Any]:
         # These are duplicated in the install-ci-tooling.py script in this repository
-        context["uv_version"] = "0.11.17"
+        context["uv_version"] = "0.11.19"
         context["pre_commit_version"] = "4.5.1"
-        context["pnpm_version"] = "11.5.0"
+        context["pnpm_version"] = "11.5.2"
         # These also in pyproject.toml and the install-ci-tooling.py script in this repository
         context["copier_version"] = "==9.15.1"
         context["copier_template_extensions_version"] = "==0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ do_not_mutate_patterns = [
     'logger\.\w+',
     # disable mutations of assert statements (for type narrowing...it often messes with the messages)
     'assert .+',
-    'f"Expected .+, got.+\{\(type\(.+\}.+\{.+',
+    'f"Expected .+, got.+\{type\(.+\}.+\{.+',
     # disable mutating untested exceptions
     'raise NotImplementedError.+',
     'raise AssertionError.+',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
+    "faker>=40.21.0",
     "pyright[nodejs]>=1.1.410",
     "pyrefly>=1.0.0",
     "mutmut@git+https://github.com/boxed/mutmut.git@e92d763eb8a6c16fb7a1f39ea34ffa6c620c9548",

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -41,16 +41,14 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code{% endraw %}{% endif %}{% raw %}
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.19.2",
+        "coderabbit.coderabbit-vscode@0.20.0",
         "ms-vscode.live-server@0.5.2025051301",
-        "MS-vsliveshare.vsliveshare@1.0.5905",
-        "github.copilot@1.388.0",
-        "github.copilot-chat@0.44.2",{% endraw %}{% if install_claude_cli %}{% raw %}
-        "anthropic.claude-code@2.1.145",{% endraw %}{% endif %}{% raw %}{% endraw %}{% if (is_child_of_copier_base_template is defined and is_child_of_copier_base_template is sameas(true)) or (is_child_of_copier_base_template is not defined and template_uses_python is defined and template_uses_python is sameas(true)) %}{% raw %}
+        "MS-vsliveshare.vsliveshare@1.0.5905",{% endraw %}{% if install_claude_cli %}{% raw %}
+        "anthropic.claude-code@2.1.169",{% endraw %}{% endif %}{% raw %}{% endraw %}{% if (is_child_of_copier_base_template is defined and is_child_of_copier_base_template is sameas(true)) or (is_child_of_copier_base_template is not defined and template_uses_python is defined and template_uses_python is sameas(true)) %}{% raw %}
 
         // Python
-        "ms-python.python@2026.5.2026032701",
-        "ms-python.vscode-pylance@2026.2.100",
+        "ms-python.python@2026.5.2026052901",
+        "ms-python.vscode-pylance@2026.2.104",
         "ms-vscode-remote.remote-containers@0.414.0",
         "charliermarsh.ruff@2026.44.0",{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_vuejs is defined and template_uses_vuejs is sameas(true) %}{% raw %}

--- a/template/.devcontainer/devcontainer.json.jinja-base
+++ b/template/.devcontainer/devcontainer.json.jinja-base
@@ -17,13 +17,6 @@
       // https://github.com/devcontainers/features/blob/main/src/aws-cli/devcontainer-feature.json
       // view latest version https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
       "version": "2.34.34"
-    },{% endraw %}{% endif %}{% raw %}{% endraw %}{% if (is_child_of_copier_base_template is defined and is_child_of_copier_base_template is sameas(true)) or (is_child_of_copier_base_template is not defined and template_uses_python is defined and template_uses_python is sameas(true)) %}{% raw %}
-    "ghcr.io/devcontainers/features/python:1.8.0": {
-      // https://github.com/devcontainers/features/blob/main/src/python/devcontainer-feature.json
-      "version": "{% endraw %}{{ python_version }}{% raw %}",
-      "installTools": false,
-      "optimize": true{% endraw %}{% if deploy_as_executable is defined and deploy_as_executable is sameas(true) %}{% raw %},
-      "enableShared": true{% endraw %}{% endif %}{% raw %}
     },{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_typescript is defined and template_uses_typescript is sameas(true) %}{% raw %}
     "ghcr.io/devcontainers/features/node:2.0.0": {
       // https://github.com/devcontainers/features/blob/main/src/node/devcontainer-feature.json

--- a/template/.devcontainer/on-create-command.sh.jinja-base
+++ b/template/.devcontainer/on-create-command.sh.jinja-base
@@ -19,4 +19,4 @@ npm install -g @beads/bd@0.57.0 # no specific reason for this version, just pinn
 
 pre-commit install --install-hooks{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}
 
-{% raw %}python .devcontainer/manual-setup-deps.py --optionally-check-lock{% endraw %}{% endif %}
+{% raw %}python .devcontainer/manual-setup-deps.py --optionally-check-lock --allow-uv-to-install-python{% endraw %}{% endif %}

--- a/template/pyproject.toml.jinja-base
+++ b/template/pyproject.toml.jinja-base
@@ -12,6 +12,7 @@ dependencies = [
     "pytest{% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov{% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly{% endraw %}{{ pytest_randomly_version }}{% raw %}",
+    "faker{% endraw %}{{ python_faker_version }}{% raw %}",
     "pyright[nodejs]{% endraw %}{{ pyright_version }}{% raw %}",
     "pyrefly{% endraw %}{{ pyrefly_version }}{% raw %}",
     "ty{% endraw %}{{ ty_version }}{% raw %}",

--- a/template/pyproject.toml.jinja-base
+++ b/template/pyproject.toml.jinja-base
@@ -13,6 +13,7 @@ dependencies = [
     "pytest-cov{% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly{% endraw %}{{ pytest_randomly_version }}{% raw %}",
     "pyright[nodejs]{% endraw %}{{ pyright_version }}{% raw %}",
+    "pyrefly{% endraw %}{{ pyrefly_version }}{% raw %}",
     "ty{% endraw %}{{ ty_version }}{% raw %}",
     "copier{% endraw %}{{ copier_version }}{% raw %}",
     "copier-template-extensions{% endraw %}{{ copier_template_extensions_version }}{% raw %}"

--- a/template/pyrefly.toml
+++ b/template/pyrefly.toml
@@ -1,0 +1,1 @@
+../pyrefly.toml

--- a/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
+++ b/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
@@ -1,21 +1,13 @@
 import subprocess
-import uuid
 from pathlib import Path
 
 import yaml
+from faker import Faker
 
 from .helpers import run_copier_task
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _SCRIPT_PATH = _PROJECT_ROOT / "src" / "copier_tasks" / "ensure_pnpm_minimum_release_age_exclude.py"
-
-
-def _pkg() -> str:
-    return uuid.uuid4().hex[:8]
-
-
-def _scoped_pkg() -> str:
-    return f"@{uuid.uuid4().hex[:4]}/{uuid.uuid4().hex[:6]}"
 
 
 class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
@@ -28,24 +20,28 @@ class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
     ) -> subprocess.CompletedProcess[str]:
         return run_copier_task(_SCRIPT_PATH, "--patterns", patterns, "--target-dir", str(target_dir), env=env)
 
-    def test_When_pnpm_not_on_path__Then_exits_nonzero_with_error(self, tmp_path: Path) -> None:
+    def test_When_pnpm_not_on_path__Then_exits_nonzero_with_error(self, tmp_path: Path, faker: Faker) -> None:
         _ = (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - frontend\n", encoding="utf-8")
 
-        result = self._run_script(patterns=_pkg(), target_dir=tmp_path, env={"PATH": ""})
+        result = self._run_script(patterns=faker.name(), target_dir=tmp_path, env={"PATH": ""})
 
         assert result.returncode != 0
         assert "pnpm" in result.stdout
 
-    def test_When_target_dir_has_no_workspace_file__Then_exits_0_and_reports_skipping(self, tmp_path: Path) -> None:
-        result = self._run_script(patterns=_pkg(), target_dir=tmp_path)
+    def test_When_target_dir_has_no_workspace_file__Then_exits_0_and_reports_skipping(
+        self, tmp_path: Path, faker: Faker
+    ) -> None:
+        result = self._run_script(patterns=faker.name(), target_dir=tmp_path)
 
         assert result.returncode == 0
         assert "not found" in result.stdout
         assert not (tmp_path / "pnpm-workspace.yaml").exists()
 
-    def test_When_workspace_has_existing_patterns__Then_new_patterns_appended(self, tmp_path: Path) -> None:
-        existing = _pkg()
-        new = _pkg()
+    def test_When_workspace_has_existing_patterns__Then_new_patterns_appended(
+        self, tmp_path: Path, faker: Faker
+    ) -> None:
+        existing = faker.name()
+        new = faker.name()
         workspace = tmp_path / "pnpm-workspace.yaml"
         _ = workspace.write_text(f"minimumReleaseAgeExclude: {existing}\n", encoding="utf-8")
 
@@ -55,9 +51,9 @@ class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
         parsed = yaml.safe_load(workspace.read_text(encoding="utf-8"))
         assert parsed["minimumReleaseAgeExclude"] == f"{existing},{new}"
 
-    def test_When_patterns_provided__Then_sets_value_in_workspace(self, tmp_path: Path) -> None:
-        scoped = _scoped_pkg()
-        plain = _pkg()
+    def test_When_patterns_provided__Then_sets_value_in_workspace(self, tmp_path: Path, faker: Faker) -> None:
+        scoped = f"{faker.name()}/{faker.name()}"
+        plain = faker.name()
         workspace = tmp_path / "pnpm-workspace.yaml"
         _ = workspace.write_text("packages:\n  - frontend\n", encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -68,6 +68,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "copier" },
     { name = "copier-template-extensions" },
+    { name = "faker" },
     { name = "mutmut" },
     { name = "pyrefly" },
     { name = "pyright", extra = ["nodejs"] },
@@ -81,6 +82,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = "==9.15.1" },
     { name = "copier-template-extensions", specifier = "==0.3.3" },
+    { name = "faker", specifier = ">=40.21.0" },
     { name = "mutmut", git = "https://github.com/boxed/mutmut.git?rev=e92d763eb8a6c16fb7a1f39ea34ffa6c620c9548" },
     { name = "pyrefly", specifier = ">=1.0.0" },
     { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.410" },
@@ -176,6 +178,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/4e/a5c8c337a1d9ac0384298ade02d322741fb5998041a5ea74d1cd2a4a1d47/dunamai-1.23.0.tar.gz", hash = "sha256:a163746de7ea5acb6dacdab3a6ad621ebc612ed1e528aaa8beedb8887fccd2c4", size = 44681, upload-time = "2024-11-18T00:00:27.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/4c/963169386309fec4f96fd61210ac0a0666887d0fb0a50205395674d20b71/dunamai-1.23.0-py3-none-any.whl", hash = "sha256:a0906d876e92441793c6a423e16a4802752e723e9c9a5aabdc5535df02dbe041", size = 26342, upload-time = "2024-11-18T00:00:25.683Z" },
+]
+
+[[package]]
+name = "faker"
+version = "40.21.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6f/d7b251fb31de7dce0e482680bf7ca876aa0043f475c04aeefa1459ea80d4/faker-40.21.0.tar.gz", hash = "sha256:2fdee1b650a723a54432db9c6dfe17cfa29d1adc8bd60520444a07698524ba4d", size = 1970295, upload-time = "2026-06-02T17:53:46.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/77/6adb5a9dcd028f687f81fc9f789591f9572cb5a46454337122add004e134/faker-40.21.0-py3-none-any.whl", hash = "sha256:cb6601b2ae8e128895dc96814d271eab6b930a2d2d7932c6f9ff26785c24ee18", size = 2008808, upload-time = "2026-06-02T17:53:44.346Z" },
 ]
 
 [[package]]
@@ -787,6 +801,15 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why is this change necessary?
Faster devcontainer build times


## How does this change address the issue?
Uses uv to install python rather than the devcontainer feature

For local devcontainer build, drops time from ~10 minutes to ~5 minutes


## What side effects does this change have?
Loses the ability for "optimizing" the python code, but seems like not that big of a loss


## How is this change tested?
Downstream repos, including ones that use pyinstaller to compile frozen python code


## Other
Switched this repo to using the pyrefly VS Code extension instead of pylance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated devcontainer extension set: several extensions refreshed to newer versions and a few extensions removed.
  * Removed a pinned Python devcontainer feature from the lock file.
  * Enhanced devcontainer setup to allow uv-based Python installation during initial setup.
  * Bumped pinned tooling versions used by the environment (uv, pnpm).
  * Added pyrefly to the managed template dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->