### PR TITLE
move ruff cache into .config folder

### DIFF
--- a/.config/pyrefly.toml
+++ b/.config/pyrefly.toml
@@ -15,7 +15,7 @@ project-includes = [
                     "../tests"
                   ]
 search-path = [".."]
-disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly things the src is excluded because it's an editable local install
+disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly thinks the src is excluded because it's an editable local install
 python-platform = "linux"
 infer-with-first-use = false # more similar to pyright. must define the empty list type when instantiated
 # "strict" enables the maximalist error set plus strict-callable-subtyping and

--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -32,6 +32,9 @@ exclude = [
 line-length = 120
 indent-width = 4
 
+# resolved relative to the cwd where ruff runs (repo root under pre-commit), so this nests the cache under .config
+cache-dir = ".config/.ruff_cache"
+
 target-version = "py312"
 
 [lint]


### PR DESCRIPTION
get more things out of repo root

it was gitignored, but in development, you still could see that folder at repo root (if IDE settings not automatically set to exclude it)

tested in this repo only
<img width="234" height="177" alt="image" src="https://github.com/user-attachments/assets/82e5c7ec-34fc-4683-bb5d-7c69c1e58f67" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to store its cache in a consistent project-local location.
  * No user-facing functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->