### PR TITLE
Tell Agents that E2E tests manage their own lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ This project is a Copier template used to generate other copier templates. It is
 ## Testing
 
 - Always run tests with an explicit path (e.g. uv run pytest tests/unit) — test runners discover all types (unit, integration, E2E...) by default.
+- Never manually start services prior to running E2E tests. The test harness boots and tears down its own services (backend, frontend, supporting services) via session fixtures.
 - When iterating on a single test, run that test in isolation first and confirm it is in the expected state (red or green) before widening to the full suite. Use the most targeted invocation available: a specific test function for Python (e.g. `uv run pytest path/to/test.py::test_name --no-cov`) or a file path and name filter for TypeScript (e.g. `pnpm test-unit path/to/test.spec.ts -t "test name" --no-coverage`). Only run the full suite once the target test behaves as expected.
 - Test coverage requirements are usually at 100%, so when running a subset of tests, always disable test coverage to avoid the test run failing for insufficient coverage.
 - Avoid magic values in comparisons in tests in all languages (like ruff rule PLR2004 specifies). Note: `1` and `0` are not magic numbers (according to PLR2004)

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -63,7 +63,7 @@ class ContextUpdater(ContextHook):
         context["pytest_asyncio_version"] = ">=1.4.0"
         context["pytest_timeout_version"] = ">=2.4.0"
         context["pytest_reserial_version"] = ">=0.6.1"
-        context["python_faker_version"] = ">=40.28.1"
+        context["python_faker_version"] = ">=40.35.0"
         #######
         context["nuxt_ui_version"] = "^4.8.1"
         context["nuxt_version"] = "^4.4.6"


### PR DESCRIPTION
## Why is this change necessary?
Claude is constantly trying to spin up services before running E2E tests


## How does this change address the issue?
Updates AGENTS.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that end-to-end tests automatically start and stop required application services, eliminating manual setup.
- **Compatibility**
  - Updated the minimum supported Faker version to 40.35.0 to ensure consistent template behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->