### PR TITLE
Pin hadolint docker image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,5 +70,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): cfc3f04c # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 632d6f5d # spellchecker:disable-line
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -228,6 +228,9 @@ repos:
     hooks:
       - id: hadolint-docker
         name: Lint Dockerfiles
+        # The hadolint pre-commit has a problem where it just always pulls the `latest` image at runtime.
+        # Explicitly pinning the image here to the same rev as the hook to patch it until https://github.com/hadolint/hadolint/pull/1177 gets resolved.
+        entry: ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
         exclude: .*\.jinja$
         description: Runs hadolint to lint Dockerfiles
 


### PR DESCRIPTION
## Why is this change necessary?
There's a bug in the hadolint pre-commit hook where it always pulls "latest" docker image instead of actually pinning an image. Which resulted in a fun scenario where things passed locally, but CI was pulling a newly released image and then failing


## How does this change address the issue?
Pins it explicitly


## What side effects does this change have?
We have to remember to bump that image sha whenever we bump the pre-commit hook


## How is this change tested?
The syntax is tested downstream (and here), but the copier update mechanism itself was not explicitly tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development container configuration.
  * Pinned the Dockerfile linting tool to a specific version and image digest for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->