### PR TITLE
Line normalization for devcontainer hash

### DIFF
--- a/.github/workflows/hash_git_files.py
+++ b/.github/workflows/hash_git_files.py
@@ -89,24 +89,15 @@ def compute_adler32(repo_path: Path, files: list[str], extra_paths: list[Path] |
             if file_path.name == "uv.lock":
                 checksum = zlib.adler32(get_uv_lock_bytes_for_hashing(file_path), checksum)
             else:
-                with file_path.open("rb") as f:
-                    while True:
-                        chunk = f.read(4096)
-                        if not chunk:
-                            break
-                        checksum = zlib.adler32(chunk, checksum)
+                # Normalize CRLF to LF so the checksum is identical on Windows (autocrlf) and Linux CI checkouts.
+                checksum = zlib.adler32(file_path.read_bytes().replace(b"\r\n", b"\n"), checksum)
         except IsADirectoryError:
             # Ignore symlinks that on windows sometimes get confused as being directories
             continue
 
     for extra_path in sorted(extra_paths or []):
         checksum = zlib.adler32(str(extra_path).encode("utf-8"), checksum)
-        with extra_path.open("rb") as f:
-            while True:
-                chunk = f.read(4096)
-                if not chunk:
-                    break
-                checksum = zlib.adler32(chunk, checksum)
+        checksum = zlib.adler32(extra_path.read_bytes().replace(b"\r\n", b"\n"), checksum)
 
     return checksum
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ This project is a Copier template used to generate other copier templates. It is
 ### Python Testing
 
 - Keep every behavioral `assert` inside the test function body — never factor assertions into helper functions or fixtures. pytest's assertion rewriting (the rich failure diff) only applies to asserts located in the test module (or conftest/registered plugins), so an `assert` hidden in an ordinary helper reports an opaque failure with no useful diff.
+- Do not apply the keyword-only parameter rule (`*`) to test functions or fixtures — pytest injects their parameters, so `*` has no effect.
 - When using `mocker.spy` on a class-level method (including inherited ones), the spy records the unbound call, so assertions need `ANY` as the first argument to match self: `spy.assert_called_once_with(ANY, expected_arg)`
 - Before writing new mock/spy helpers, check the `tests/unit/` folder for pre-built helpers in files like `fixtures.py` or `*mocks.py`
 - When a test needs a fixture only for its side effects (not its return value), use `@pytest.mark.usefixtures(fixture_name.__name__)` instead of adding an unused parameter with a noqa comment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ This project is a Copier template used to generate other copier templates. It is
 ### Python Testing
 
 - Keep every behavioral `assert` inside the test function body — never factor assertions into helper functions or fixtures. pytest's assertion rewriting (the rich failure diff) only applies to asserts located in the test module (or conftest/registered plugins), so an `assert` hidden in an ordinary helper reports an opaque failure with no useful diff.
-- Do not apply the keyword-only parameter rule (`*`) to test functions or fixtures — pytest injects their parameters, so `*` has no effect.
+- Do not apply the keyword-only parameter rule (`*`) to test functions or fixtures — pytest injects its parameters, so `*` has no effect.
 - When using `mocker.spy` on a class-level method (including inherited ones), the spy records the unbound call, so assertions need `ANY` as the first argument to match self: `spy.assert_called_once_with(ANY, expected_arg)`
 - Before writing new mock/spy helpers, check the `tests/unit/` folder for pre-built helpers in files like `fixtures.py` or `*mocks.py`
 - When a test needs a fixture only for its side effects (not its return value), use `@pytest.mark.usefixtures(fixture_name.__name__)` instead of adding an unused parameter with a noqa comment


### PR DESCRIPTION
## Why is this change necessary?
When developers are not using a devcontainer and are running on windows, the CRLF vs LF generated different hashs


## How does this change address the issue?
Normalizes line endings


## What side effects does this change have?
N/A

## How is this change tested?
Downstream repo


## Other
Tweaked AGENTS.md to stop Coderabbit from telling us to use kwargs for test functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file integrity checks by consistently normalizing line endings before hashing.
  * Preserved special handling for lockfiles and continued ignoring directory-like symbolic links.

* **Documentation**
  * Clarified Python testing guidelines for pytest-injected parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->