### PR TITLE
Fix: claude bash-chain-guard quoting fix and split error messages

### DIFF
--- a/.claude/hooks/bash-chain-guard.js
+++ b/.claude/hooks/bash-chain-guard.js
@@ -1,7 +1,17 @@
 #!/usr/bin/env node
 // PreToolUse hook: blocks command chaining in Bash tool calls
-// Detects &&/|| which violate AGENTS.md: "execute exactly one command per tool call"
+// Enforces AGENTS.md: "execute exactly one command per tool call"
+// Quoted spans and backslash-escapes are removed before scanning, so a `;` inside a string
+// literal (or the trailing `\;` of `find -exec`) is not mistaken for a chain.
 // Once https://github.com/anthropics/claude-code/issues/16561 is resolved, this should no longer be necessary
+// Improvements based on https://github.com/iandunn/dotfiles/blob/main/claude/hooks/block-chained-commands.js
+
+const CHAIN_OPERATORS = /&&|\|\||;/; // a single `|` is a pipe, which is allowed
+const BACKGROUND_AMPERSAND = /(?<![<>])&(?!>)/; // a lone `&` backgrounds the command, but `2>&1` and `&>file` are redirections
+
+function stripQuotedAndEscaped(command) {
+  return command.replace(/\\.|'[^']*'|"(?:\\.|[^"\\])*"/g, "");
+}
 
 let input = "";
 process.stdin.on("data", (chunk) => {
@@ -11,12 +21,21 @@ process.stdin.on("end", () => {
   try {
     const data = JSON.parse(input);
     const command = (data.tool_input?.command || "").trim();
+    const scannable = stripQuotedAndEscaped(command);
 
-    if (/\s(&&|\|\||;)\s|\s&(\s|$)/.test(command)) {
+    if (CHAIN_OPERATORS.test(scannable)) {
       process.stderr.write(
-        "AGENTS.md violation: never chain commands with &&, ||, ;, or &. " +
+        "AGENTS.md violation: never chain commands with &&, ||, or ;. " +
           "Run one command per tool call. " +
           "Use cd as a separate prior tool call instead of cd && ...",
+      );
+      process.exit(2);
+    }
+
+    if (BACKGROUND_AMPERSAND.test(scannable)) {
+      process.stderr.write(
+        "AGENTS.md violation: never background a command with &. " +
+          "Use the Bash tool's run_in_background option instead.",
       );
       process.exit(2);
     }

--- a/.claude/hooks/bash-chain-guard.js
+++ b/.claude/hooks/bash-chain-guard.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // PreToolUse hook: blocks command chaining in Bash tool calls
 // Enforces AGENTS.md: "execute exactly one command per tool call"
-// Quoted spans and backslash-escapes are removed before scanning, so a `;` inside a string
-// literal (or the trailing `\;` of `find -exec`) is not mistaken for a chain.
+// Quoted spans and backslash-escapes are replaced with a space before scanning, so a `;` inside a
+// string literal (or the trailing `\;` of `find -exec`) is not mistaken for a chain. Replacing with
+// a space rather than deleting keeps tokens separate, so `printf hi >\x&` cannot collapse to
+// `printf hi >&` and hide the backgrounding `&` behind the redirection lookbehind.
 // Once https://github.com/anthropics/claude-code/issues/16561 is resolved, this should no longer be necessary
 // Improvements based on https://github.com/iandunn/dotfiles/blob/main/claude/hooks/block-chained-commands.js
 
@@ -10,7 +12,7 @@ const CHAIN_OPERATORS = /&&|\|\||;/; // a single `|` is a pipe, which is allowed
 const BACKGROUND_AMPERSAND = /(?<![<>])&(?!>)/; // a lone `&` backgrounds the command, but `2>&1` and `&>file` are redirections
 
 function stripQuotedAndEscaped(command) {
-  return command.replace(/\\.|'[^']*'|"(?:\\.|[^"\\])*"/g, "");
+  return command.replace(/\\.|'[^']*'|"(?:\\.|[^"\\])*"/g, " ");
 }
 
 let input = "";


### PR DESCRIPTION
## Why is this change necessary?

The chain-detection regex was `/\s(&&|\|\||;)\s|\s&(\s|$)/`, which requires whitespace on **both** sides of the operator. That makes it both too narrow and too broad, and every repo on this template has the same holes today.

Missed (chaining that should be blocked, but ran through):

- `cd /some/path; git diff` — no space before the semicolon
- `cd a&&ls` — no spaces at all

False-positived (legitimate single commands that got blocked):

- `find . -name x -exec rm {} \;` — the trailing `\;` of `find -exec`
- `cat x.json | jq -r ".a; .b"` — a semicolon inside a string literal

The regex never accounted for shell quoting, so it could not tell a chain operator from the same character inside a quoted or escaped span.

## How does this change address the issue?

Strip quoted spans and backslash-escapes first, then test what remains:

```js
const CHAIN_OPERATORS = /&&|\|\||;/; // a single `|` is a pipe, which is allowed
const BACKGROUND_AMPERSAND = /(?<![<>])&(?!>)/; // a lone `&` backgrounds the command, but `2>&1` and `&>file` are redirections

function stripQuotedAndEscaped(command) {
  return command.replace(/\\.|'[^']*'|"(?:\\.|[^"\\])*"/g, "");
}
```

Because the operators are matched against the stripped string, they no longer need whitespace anchors — which is what fixes the missed cases.

Chaining and backgrounding are also split into two separate checks so each error message names its own fix. The backgrounding message now points at the Bash tool's `run_in_background` option, which the single combined message could not do. `BACKGROUND_AMPERSAND` uses lookaround so `2>&1` and `&>file` are treated as redirections rather than backgrounding.

## What side effects does this change have?

- Commands that previously slipped through are now blocked. This is the intended fix, but agents mid-task in existing repos will start seeing exit-2 on `cd x; y` forms that used to run.
- `find -exec ... \;` and quoted semicolons stop being blocked, so anything that had worked around the false positive no longer needs to.
- Pipes (`|`) remain allowed, unchanged.
- Failure mode is unchanged: the hook still silently no-ops on any internal error rather than blocking.

## How is this change tested?

Smoke-tested by piping hook-shaped JSON into the real hook and checking the exit code:

| command | expected | result |
| --- | --- | --- |
| `cd /some/path; git diff` | blocked | blocked (regression case) |
| `cd a&&ls` | blocked | blocked (regression case) |
| `pnpm dev &` | blocked, names `run_in_background` | blocked |
| `find . -name x -exec rm {} \;` | passes | passes |
| `cat x.json \| jq -r ".a; .b"` | passes | passes |
| `uv run pytest tests/unit 2>&1 \| tail -20` | passes | passes |

Invocation used:

```bash
echo '{"tool_input":{"command":"cd /some/path; git diff"}}' | node .claude/hooks/bash-chain-guard.js
```

Also, I played around with it for a while in a downstream repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command safety checks by detecting command chaining and background execution.
  * Preserved support for valid output redirection patterns.
  * Added clearer guidance when a command is blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->